### PR TITLE
refactor: use "strategy" instead of "standard"

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -58,57 +58,57 @@ def get_soso_common():
     return file_path
 
 
-def get_sssom_file_path(standard):
-    """Return the SSSOM file path for the specified metadata standard.
+def get_sssom_file_path(strategy):
+    """Return the SSSOM file path for the specified strategy.
 
     Parameters
     ----------
-    standard : str
-        Metadata standard. Can be: EML.
+    strategy : str
+        Metadata strategy. Can be: EML.
 
     Returns
     -------
     PosixPath
         File path.
     """
-    file_name = "soso-" + str.lower(standard) + ".sssom.tsv"
+    file_name = "soso-" + str.lower(strategy) + ".sssom.tsv"
     file_path = resources.files("soso.data").joinpath(file_name)
     return file_path
 
 
-def get_example_metadata_file_path(standard):
+def get_example_metadata_file_path(strategy):
     """Return the file path of an example metadata file.
 
     Parameters
     ----------
-    standard : str
-        Metadata standard. Can be: EML.
+    strategy : str
+        Metadata strategy. Can be: EML.
 
     Returns
     -------
     PosixPath
         File path.
     """
-    if standard.lower() == "eml":
+    if strategy.lower() == "eml":
         file_path = resources.files("soso.data").joinpath("eml.xml")
     else:
         raise ValueError("Invalid choice!")
     return file_path
 
 
-def read_sssom(standard):
-    """Return the SSSOM for the specified metadata standard.
+def read_sssom(strategy):
+    """Return the SSSOM for the specified strategy.
 
     Parameters
     ----------
-    standard : str
-        Metadata standard. Can be: EML.
+    strategy : str
+        Metadata strategy. Can be: EML.
 
     Returns
     -------
     DataFrame
         Pandas dataframe.
     """
-    sssom_file_path = get_sssom_file_path(standard)
+    sssom_file_path = get_sssom_file_path(strategy)
     sssom = pd.read_csv(sssom_file_path, delimiter="\t")
     return sssom

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -72,5 +72,5 @@ def test_read_sssom_returns_dataframe(strategy_names):
 def test_get_example_metadata_file_path_returns_path(strategy_names):
     """Test that get_example_metadata returns a path."""
     for strategy in strategy_names:
-        file_path = get_example_metadata_file_path(standard=strategy)
+        file_path = get_example_metadata_file_path(strategy=strategy)
         assert isinstance(file_path, PosixPath)


### PR DESCRIPTION
Use the name "strategy" instead of "standard" for parameters that control the conversion methods to be used on a metadata file. Do this for the sake of consistency.