### PR TITLE
ci: simplify pylint calls with pyproject.toml

### DIFF
--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -68,7 +68,7 @@ Our project uses a couple tools to ensure the code base has a consistent
 style and format as it grows. We use `Black`_ for code formatting and `Pylint`_ for static code analysis. Both can be run from the command line::
 
     black src/ tests/
-    pylint src/ tests/ --disable=C0103,W0621,R0904
+    pylint src/ tests/
 
 .. _Black: https://black.readthedocs.io/en/stable/
 .. _Pylint: https://pylint.pycqa.org/en/latest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ upload_to_pypi = false                      # don't auto-upload to PyPI
 remove_dist = false                         # don't remove dists
 patch_without_tag = false                    # patch release by default
 
+[tool.pylint.'MESSAGES.CONTROL']
+disable = "invalid-name,redefined-outer-name,too-many-public-methods"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Simplify pylint calls by declaring arguments in the pyproject.toml file rather than passing them manually with each pylint call.