### PR TITLE
refactor: re-enable pylint checks to improve code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ remove_dist = false                         # don't remove dists
 patch_without_tag = false                    # patch release by default
 
 [tool.pylint.'MESSAGES.CONTROL']
-disable = "invalid-name,redefined-outer-name,too-many-public-methods"
+disable = "too-many-public-methods"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -38,8 +38,8 @@ def validate(graph):
         if not conforms:
             warnings.warn(results_text)
         return conforms
-    except urllib.error.URLError as e:
-        warnings.warn(e)
+    except urllib.error.URLError as errors:
+        warnings.warn(errors)
         return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,8 @@ def strategy_instance(request):
     # Initialize strategy instances with a metadata file to fulfill the
     # required file argument.
     if request.param is EML:
-        strategy_instance = request.param(file=get_example_metadata_file_path("EML"))
-    return strategy_instance
+        res = request.param(file=get_example_metadata_file_path("EML"))
+    return res
 
 
 @pytest.fixture

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -24,9 +24,9 @@ def test_validate_returns_no_warning_when_valid(internet_connection):
     """Test validate returns no warning when the graph is valid."""
     if not internet_connection:
         pytest.skip("Internet connection is not available.")
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as list_of_warnings:
         validate("tests/full.jsonld")
-        for warning in w:
+        for warning in list_of_warnings:
             assert not issubclass(warning.category, UserWarning)
 
 


### PR DESCRIPTION
Re-enable a couple pylint checks to improve code readability, reduce accidental introduction of errors, and simplify future debugging.