### PR TITLE
feat: get url property from argument (#5)

### DIFF
--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -23,7 +23,7 @@ class StrategyInterface:
         """Return a short summary describing a dataset."""
 
     def get_url(self):
-        """Return location of a page describing the dataset."""
+        """Return the location of a page describing the dataset."""
 
     def get_same_as(self):
         """Return other URLs that can be used to access the dataset page.

--- a/src/soso/main.py
+++ b/src/soso/main.py
@@ -49,4 +49,11 @@ def convert(file, strategy, **kwargs):
         # "wasGeneratedBy": strategy.get_was_generated_by(),
         # "checksum": strategy.get_checksum(),
     }
+
+    # Remove properties where get methods returned None, so the user is
+    # return a clean graph.
+    for key, value in list(graph.items()):
+        if value is None:
+            del graph[key]
+
     return dumps(graph)

--- a/src/soso/main.py
+++ b/src/soso/main.py
@@ -4,12 +4,13 @@ from json import dumps
 from soso.strategies.eml import EML
 
 
-def convert(file, strategy):
+def convert(file, strategy, **kwargs):
     """Return SOSO markup for a metadata document and specified strategy."""
 
-    # Load the strategy based on user choice
+    # Load the strategy based on user choice. Pass kwargs, so the strategy may
+    # operate on them.
     if strategy == "eml":
-        strategy = EML(file)
+        strategy = EML(file, **kwargs)
     else:
         raise ValueError("Invalid choice!")
 
@@ -19,7 +20,7 @@ def convert(file, strategy):
         "@type": "Dataset",
         "name": strategy.get_name(),
         "description": strategy.get_description(),
-        # "url": strategy.get_url(),
+        "url": strategy.get_url(),
         # "sameAs": strategy.get_same_as(),
         # "version": strategy.get_version(),
         # "isAccessibleForFree": strategy.get_is_accessible_for_free(),

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -5,12 +5,24 @@ from soso.interface import StrategyInterface
 
 
 class EML(StrategyInterface):
-    """Define the strategy for EML."""
+    """Define the strategy for EML.
 
-    def __init__(self, file=None):
+    Notes
+    -----
+    Not all SOSO properties map to EML. Such properties may be
+    defined with `kwargs` where values are of the expected types (see the
+    `SOSO guidelines <https://github.com/ESIPFed/science-on-schema.org/blob
+    /master/guides/Dataset.md>`_ for more information on each property):
+
+    - url
+    """
+
+    def __init__(self, file=None, **kwargs):
         """Initialize the strategy."""
         if file is not None:
             super().__init__(metadata=etree.parse(file))
+        if kwargs is not None:
+            self.kwargs = kwargs  # for method access to kwargs
 
     def get_name(self):
         name = self.metadata.xpath(".//dataset/title")
@@ -20,9 +32,10 @@ class EML(StrategyInterface):
         description = self.metadata.xpath(".//dataset/abstract")
         return description[0].text
 
-    # def get_url(self):
-    #     return "url from EML"
-    #
+    def get_url(self):
+        url = self.kwargs.get("url")
+        return url
+
     # def get_same_as(self):
     #     return "same_as from EML"
     #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Configure the test suite."""
 
 import socket
+from urllib.parse import urlparse
 import pytest
 from soso.strategies.eml import EML
 from soso.utilities import get_example_metadata_file_path
@@ -18,7 +19,10 @@ def strategy_instance(request):
     # Initialize strategy instances with a metadata file to fulfill the
     # required file argument.
     if request.param is EML:
-        res = request.param(file=get_example_metadata_file_path("EML"))
+        res = request.param(
+            file=get_example_metadata_file_path("EML"),
+            url="https://example.com",  # url doesn't map to EML so use kwargs
+        )
     return res
 
 
@@ -30,7 +34,7 @@ def soso_properties():
         "@type",
         "name",
         "description",
-        # "url",
+        "url",
         # "sameAs",
         # "version",
         # "isAccessibleForFree",
@@ -67,7 +71,7 @@ def interface_methods():
     res = [
         "get_name",
         "get_description",
-        # "get_url",
+        "get_url",
         # "get_same_as",
         # "get_version",
         # "get_is_accessible_for_free",
@@ -113,4 +117,13 @@ def internet_connection():
         socket.create_connection(("8.8.8.8", 53), timeout=5)
         return True
     except OSError:
+        return False
+
+
+def is_url(url):
+    """Check if a string is a URL."""
+    try:
+        res = urlparse(url)
+        return all([res.scheme, res.netloc])
+    except ValueError:
         return False

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,14 @@
+"""Test the test configuration."""
+
+from tests.conftest import is_url
+
+
+def test_is_url():
+    """Test that the is_url function returns True for valid URLs."""
+    assert is_url("https://example.com")
+    assert is_url("http://example.com")
+    assert is_url("ftp://example.com")
+    assert is_url("https://example.com/path")
+    assert is_url("https://example.com/path/")
+    assert is_url("example.com") is False
+    assert is_url("example.com/path") is False

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,6 +1,7 @@
 """Test the strategies."""
 
 from soso.interface import StrategyInterface
+from tests.conftest import is_url
 
 
 def test_strategy_inherits_strategy_interface(strategy_instance):
@@ -39,14 +40,13 @@ def test_get_description_returns_expected_type(strategy_instance):
         assert isinstance(res, str)
 
 
-# def test_get_url_returns_expected_type(strategy_instance):
-#     """Test that the get_url method returns a string."""
-#     res = strategy_instance.get_url()
-#     # Test for a URL pattern
-#     if res is not None:
-#         assert isinstance(res, str)
-#
-#
+def test_get_url_returns_expected_type(strategy_instance):
+    """Test that the get_url method returns a string."""
+    res = strategy_instance.get_url()
+    if res is not None:
+        assert is_url(res)
+
+
 # def test_get_same_as_returns_expected_type(strategy_instance):
 #     """Test that the get_same_as method returns a string."""
 #     res = strategy_instance.get_same_as()


### PR DESCRIPTION
Get the SOSO "url" property for the EML strategy from a user supplied argument, because there is no mapping of this property to the EML schema, and therefore no way to derive this information from an EML metadata file.

Use the flexible kwargs parameter as a solution to other unmappable properties, for the EML strategy and other metadata strategies as well. Alert users to unmappable properties and their expected value types, so they may be supplied correctly.

Create a function to test that get_url returns a URL formatted string.