### PR TITLE
refactor: enhance clarity of the public-facing API

### DIFF
--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -2,28 +2,46 @@
 
 
 class StrategyInterface:
-    """Define the strategy interface.
+    """Define the interface that each conversion strategy must implement.
 
     Attributes
     ----------
-    metadata : object
-        The metadata object, such as an XML tree or JSON object, used by
-        strategy methods to create SOSO properties. The object is created upon
-        initialization, when a strategy instance reads a metadata file.
+    metadata : object or None
+        The metadata object, which could be an XML tree, a JSON object, or
+        another suitable representation. This object is utilized by strategy
+        methods to generate SOSO properties.
+    kwargs : dict or None
+        Additional keyword arguments that can be utilized to define SOSO
+        properties that don't directly correspond to metadata fields.
     """
 
-    def __init__(self, metadata=None):
+    def __init__(self, metadata=None, **kwargs):
         """Return the strategy attributes."""
         self.metadata = metadata
+        self.kwargs = kwargs
 
     def get_name(self):
-        """Return a descriptive name of a dataset."""
+        """Return a descriptive name of a dataset.
+
+        Returns
+        -------
+        str"""
 
     def get_description(self):
-        """Return a short summary describing a dataset."""
+        """Return a short summary describing a dataset.
+
+        Returns
+        -------
+        str"""
 
     def get_url(self):
-        """Return the location of a page describing the dataset."""
+        """Return the location of a page describing the dataset.
+
+        Returns
+        -------
+        str
+            A URL.
+        """
 
     def get_same_as(self):
         """Return other URLs that can be used to access the dataset page.

--- a/src/soso/main.py
+++ b/src/soso/main.py
@@ -5,9 +5,28 @@ from soso.strategies.eml import EML
 
 
 def convert(file, strategy, **kwargs):
-    """Return SOSO markup for a metadata document and specified strategy."""
+    """Return SOSO markup for a metadata file and specified strategy.
 
-    # Load the strategy based on user choice. Pass kwargs, so the strategy may
+    Parameters
+    ----------
+    file : str
+        The path to the metadata file. Refer to the strategy's documentation
+        for a list of supported file types.
+    strategy : str
+        The conversion strategy to be employed. Available strategies include:
+        "EML".
+    **kwargs : dict
+        Additional keyword arguments for creating SOSO properties not covered
+        by the chosen `strategy`. Check the Notes section in the strategy's
+        documentation for more information.
+
+    Returns
+    -------
+    str
+        The SOSO graph in JSON-LD format.
+    """
+
+    # Load the strategy based on user choice. Pass kwargs, so the strategy can
     # operate on them.
     if strategy == "eml":
         strategy = EML(file, **kwargs)

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -5,24 +5,35 @@ from soso.interface import StrategyInterface
 
 
 class EML(StrategyInterface):
-    """Define the strategy for EML.
+    """Define the conversion strategy for EML (Ecological Metadata Language).
+
+    Parameters
+    ----------
+    file : str
+        The path to the metadata file. This should be an XML file in EML
+        format.
+    **kwargs : dict
+        Additional keyword arguments that can be utilized to define SOSO
+        properties that don't directly correspond to metadata fields. See
+        Notes for more information.
 
     Notes
     -----
-    Not all SOSO properties map to EML. Such properties may be
-    defined with `kwargs` where values are of the expected types (see the
-    `SOSO guidelines <https://github.com/ESIPFed/science-on-schema.org/blob
-    /master/guides/Dataset.md>`_ for more information on each property):
+    Not all SOSO properties have a direct mapping to EML metadata. Such properties
+    can be specified using `kwargs`, where the keys represent property names, and
+    the values define the property types (provided as strings or dictionaries).
+    Refer to the `SOSO guidelines <https://github.com/ESIPFed/science-on-schema.org/blob
+    /master/guides/Dataset.md>`_ for detailed insights into each property.
+
+    Unmappable properties:
 
     - url
     """
 
-    def __init__(self, file=None, **kwargs):
+    def __init__(self, file, **kwargs):
         """Initialize the strategy."""
-        if file is not None:
-            super().__init__(metadata=etree.parse(file))
-        if kwargs is not None:
-            self.kwargs = kwargs  # for method access to kwargs
+        super().__init__(metadata=etree.parse(file))
+        self.kwargs = kwargs
 
     def get_name(self):
         name = self.metadata.xpath(".//dataset/title")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,8 @@ def strategy_names():
 @pytest.fixture(params=[EML])
 def strategy_instance(request):
     """Return the strategy instances."""
-    # Initialize strategy instances with a metadata file to fulfill the
-    # required file argument.
     if request.param is EML:
-        res = request.param(
-            file=get_example_metadata_file_path("EML"),
-            url="https://example.com",  # url doesn't map to EML so use kwargs
-        )
+        res = request.param(file=get_example_metadata_file_path("EML"))
     return res
 
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -4,8 +4,13 @@ from soso.interface import StrategyInterface
 
 
 def test_interface_has_metadata_attribute():
-    """Test that the StrategyInterface class has a meta attribute."""
+    """Test that the StrategyInterface class has a metadata attribute."""
     assert hasattr(StrategyInterface(), "metadata")
+
+
+def test_interface_has_kwargs_attribute():
+    """Test that the StrategyInterface class has a kwargs attribute."""
+    assert hasattr(StrategyInterface(), "kwargs")
 
 
 def test_interface_has_methods(interface_methods):

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -42,6 +42,8 @@ def test_get_description_returns_expected_type(strategy_instance):
 
 def test_get_url_returns_expected_type(strategy_instance):
     """Test that the get_url method returns a string."""
+    # url doesn't map to EML so use kwargs
+    strategy_instance.kwargs = {"url": "https://example.com"}
     res = strategy_instance.get_url()
     if res is not None:
         assert is_url(res)


### PR DESCRIPTION
Add clarifying docstrings to the public-facing API to improve usage comprehension.

Reorganize method tests to define kwargs within the tests themselves instead of globally during strategy instantiation in conftest.py, preserving focused test scope.