### PR TITLE
fix: add missing note to EML strategy (#5)

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -28,6 +28,7 @@ class EML(StrategyInterface):
     Unmappable properties:
 
     - url
+    - sameAs
     - version
     """
 


### PR DESCRIPTION
Add missing note to the EML strategy documentation on how to add the 'sameAs' property to the returned graph.