### PR TITLE
ci: ignore pylint c-extension-no-member messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ remove_dist = false                         # don't remove dists
 patch_without_tag = false                    # patch release by default
 
 [tool.pylint.'MESSAGES.CONTROL']
-disable = "too-many-public-methods"
+disable = "too-many-public-methods,c-extension-no-member"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Ignore pylint 'c-extension-no-member' (I1101) messages, originating from lxml, for sake of a readable message log.

Another option, adding lxml to the pylint --extension-pkg-allow-list, may run arbitrary code and is a decision I shouldn't make for collaborators running pylint in the context of this project.