### PR TITLE
fix: add missing return type to method docstring (#5)

### DIFF
--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -220,7 +220,12 @@ class StrategyInterface:
         """
 
     def get_contributor(self):
-        """Return the contributor(s) of a dataset."""
+        """Return the contributor(s) of a dataset.
+
+        Returns
+        -------
+        dict
+        """
 
     def get_provider(self):
         """Return the provider of a dataset.


### PR DESCRIPTION
Add the missing return type to the get_contributor method docstring. This should have been apart of
a42bd1121c92899d279adcfd630e0af00ba66e15