### PR TITLE
fix: return None creator/contributor for readability

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -204,7 +204,10 @@ class EML(StrategyInterface):
                 "identifier": convert_user_id(item.xpath("userId")),
             }
             creator.append(res)
-        creator = {"@list": creator}  # preserve creator order
+        if len(creator) != 0:
+            creator = {"@list": creator}  # to preserve order
+        else:
+            creator = None  # for readability
         return creator
 
     def get_contributor(self):
@@ -224,7 +227,10 @@ class EML(StrategyInterface):
                 },
             }
             contributor.append(res)
-        contributor = {"@list": contributor}  # preserve contributor order
+        if len(contributor) != 0:
+            contributor = {"@list": contributor}  # to preserve order
+        else:
+            contributor = None  # for readability
         return contributor
 
     def get_provider(self):


### PR DESCRIPTION
Update the behavior to return 'None' for empty 'creator' and 'contributor' properties, enhancing readability.

To maintain the order of 'creator' and 'contributor' properties, they are now enclosed in an '@list' wrapper. When 'creator' or 'contributor' is empty, an empty '@list' wrapper is returned to the graph. The use of 'None' facilitates the efficient removal of empty values from the graph as a final step in 'main.convert' before it is returned to the user.