### PR TITLE
fix: note provider is unmappable (#5)

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -37,6 +37,7 @@ class EML(StrategyInterface):
     - potentialAction
     - dateCreated
     - expires
+    - provider
     - wasRevisionOf
     """
 


### PR DESCRIPTION
Note that the 'provider' property is unmappable and can only be added via kwargs. This should have been apart of
ed2911ff1459c50451977ccaf7919ffd33531a33