### PR TITLE
fix: note publisher is unmappable (#5)

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -38,6 +38,7 @@ class EML(StrategyInterface):
     - dateCreated
     - expires
     - provider
+    - publisher
     - wasRevisionOf
     """
 


### PR DESCRIPTION
Note that the 'publisher' property is unmappable and can only be added via kwargs. This should have been apart of
f5f8f826817f98174813a53c1b9fa67a97275abb