### PR TITLE
refactor: rename method for readability

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -29,7 +29,7 @@ def validate(graph):
     try:
         res = pyshacl.validate(
             data_graph=graph,
-            shacl_graph=str(get_soso_common()),
+            shacl_graph=str(get_shacl_file_path()),
             data_graph_format="json-ld",
             shacl_graph_format="turtle",
         )
@@ -43,8 +43,8 @@ def validate(graph):
         return None
 
 
-def get_soso_common():
-    """Return the path to the SHACL shape file for the SOSO dataset graph.
+def get_shacl_file_path():
+    """Return the SHACL shape file path for the SOSO dataset graph.
 
     The shape file is for the current release version of the SOSO dataset
     graph.

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,7 @@ from soso.utilities import validate
 from soso.utilities import get_sssom_file_path
 from soso.utilities import read_sssom
 from soso.utilities import get_example_metadata_file_path
+from soso.utilities import get_shacl_file_path
 
 
 @pytest.mark.internet_required
@@ -74,3 +75,9 @@ def test_get_example_metadata_file_path_returns_path(strategy_names):
     for strategy in strategy_names:
         file_path = get_example_metadata_file_path(strategy=strategy)
         assert isinstance(file_path, PosixPath)
+
+
+def test_get_shacl_file_path_returns_path():
+    """Test that get_shacl_file_path returns a path."""
+    file_path = get_shacl_file_path()
+    assert isinstance(file_path, PosixPath)


### PR DESCRIPTION
Rename 'get_soso_common' to improve understanding and align with the naming convention used for other methods that retrieve file paths.