### PR TITLE
ci: use 'black' version 23.7.0

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,10 +32,12 @@ jobs:
       with:
         jupyter: true
         src: ./src
+        version: "23.7.0"
     - uses: psf/black@stable
       with:
         jupyter: true
         src: ./tests
+        version: "23.7.0"
 
       # Analyze code but don't error on issues. This check encourages best
       # practices and offers flexibility in adoption.


### PR DESCRIPTION
Use 'black' version 23.7.0 to match the version currently specified in the environment.yml and requirements.txt files and to prevent CI failures.