### PR TITLE
docs: fix local test instructions

### DIFF
--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -40,7 +40,7 @@ Here are a sequence of steps to help with your code contribution:
 1. Fork the project repository on GitHub.
 2. Create a `feature branch` from the `development` branch.
 3. Install the package by running ``poetry install`` at the command line.
-4. Verify that all tests pass on your system by running ``pytest src/`` at the command line. In case of failures, conduct a thorough investigation. If you require assistance in diagnosing the issue, follow the guidelines for filing :ref:`bug-reports`.
+4. Verify that all tests pass on your system by running ``pytest`` at the command line. In case of failures, conduct a thorough investigation. If you require assistance in diagnosing the issue, follow the guidelines for filing :ref:`bug-reports`.
 5. Construct test cases that effectively illustrate the bug or feature.
 6. Implement your changes, including any relevant documentation updates following the `NumPy`_ convention for docstrings.
 7. Re-run the complete test suite to ensure the success of all tests.


### PR DESCRIPTION
Correct local testing instructions in the Contributor's Guide to prevent confusion caused by errors thrown during command execution.