### PR TITLE
ci: ignore pylint R0912 for is_property_type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,7 @@ def is_property_type(results, expected_types):
     When type matching, the namespace prefix of an expected type is not used.
     Only the suffix is used.
     """
+    # pylint: disable=R0912
     # Prepare the results and expected_types for iteration
     if isinstance(results, dict) and results.get("@list") is not None:
         results = results.get("@list")  # Flatten @list to facilitate checking


### PR DESCRIPTION
Ignore the Pylint warning about 'too many branches' (R0912) in the case of tests.conftest.is_property_type, as the benefits of refactoring are ambiguous.