### PR TITLE
test: strategy methods return None, not null values

### DIFF
--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -2,6 +2,7 @@
 
 from tests.conftest import is_url
 from tests.conftest import is_property_type
+from tests.conftest import is_not_null
 
 
 def test_is_url():
@@ -69,3 +70,58 @@ def test_is_property_type_returns_true_for_subsets():
         results={"@type": "schema:DefinedTerm"}, expected_types=things
     )
     assert is_property_type("some text", expected_types=things)
+
+
+def test_is_not_null_for_dictionaries():
+    """Test that the is_not_null function returns True for non-empty
+    dictionaries, and False otherwise."""
+
+    # Single non-null dictionaries should pass
+    res = {"@type": "schema:Text", "name": "some text"}
+    assert is_not_null(res)
+    res = {"@type": "schema:Text", "@id": "https://example.com"}
+    assert is_not_null(res)
+    res = {"@id": "https://example.com"}
+    assert is_not_null(res)
+
+    # Single dictionary w/some null results should pass
+    res = {"@type": "schema:Text", "name": "some text", "description": ""}
+    assert is_not_null(res)
+
+    # List of non-null dictionaries should pass
+    res = [
+        {"@type": "schema:Text", "name": "some text"},
+        {"@type": "schema:Text", "@id": "https://example.com"},
+        {"@id": "https://example.com"},
+    ]
+    assert is_not_null(res)
+    res = [
+        {"name": ""},  # even when one is null
+        {"@type": "schema:Text", "@id": "https://example.com"},
+        {"@id": "https://example.com"},
+    ]
+    assert is_not_null(res)
+
+    # Single null dictionaries should fail
+    res = {"@type": "schema:Text"}  # once @type is removed, nothing is left
+    assert is_not_null(res) is False
+    res = {"@type": "schema:Text", "@id": ""}
+    assert is_not_null(res) is False
+
+    # List of null dictionaries should fail
+    res = [
+        {"@type": "schema:Text", "name": ""},
+        {"@type": "schema:Text", "@id": ""},
+        {"@id": ""},
+    ]
+    assert is_not_null(res) is False
+
+
+def test_is_not_null_for_non_dictionaries():
+    """Test that the is_not_null function returns True for non-null results,
+    and False otherwise."""
+    # schema:Text, schema:URL, schema:Number, schema:Boolean, should pass
+    assert is_not_null("some text")
+    assert is_not_null("https://example.com")
+    assert is_not_null(123)
+    assert is_not_null(True)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -2,6 +2,7 @@
 
 from soso.interface import StrategyInterface
 from tests.conftest import is_property_type
+from tests.conftest import is_not_null
 
 
 def test_strategy_inherits_strategy_interface(strategy_instance):
@@ -30,6 +31,7 @@ def test_get_name_returns_expected_type(strategy_instance):
     """Test that the get_name method returns the expected type."""
     res = strategy_instance.get_name()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Text"])
 
 
@@ -37,6 +39,7 @@ def test_get_description_returns_expected_type(strategy_instance):
     """Test that the get_description method returns the expected type."""
     res = strategy_instance.get_description()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Text"])
 
 
@@ -46,6 +49,7 @@ def test_get_url_returns_expected_type(strategy_instance):
     strategy_instance.kwargs = {"url": "https://example.com"}
     res = strategy_instance.get_url()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:URL"])
 
 
@@ -54,6 +58,7 @@ def test_get_same_as_returns_expected_type(strategy_instance):
     strategy_instance.kwargs = {"sameAs": "https://example.com"}
     res = strategy_instance.get_same_as()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:URL"])
 
 
@@ -64,6 +69,7 @@ def test_get_version_returns_expected_type(strategy_instance):
         strategy_instance.kwargs = {"version": value}
         res = strategy_instance.get_version()
         if res is not None:
+            assert is_not_null(res)
             assert is_property_type(res, ["schema:Text", "schema:Number"])
 
 
@@ -73,6 +79,7 @@ def test_get_get_is_accessible_for_free_returns_expected_type(strategy_instance)
     strategy_instance.kwargs = {"isAccessibleForFree": True}
     res = strategy_instance.get_is_accessible_for_free()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Boolean"])
 
 
@@ -80,6 +87,7 @@ def test_get_keywords_returns_expected_type(strategy_instance):
     """Test that the get_keywords method returns the expected type."""
     res = strategy_instance.get_keywords()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Text", "schema:DefinedTerm"])
 
 
@@ -87,6 +95,7 @@ def test_get_identifier_returns_expected_type(strategy_instance):
     """Test that the get_identifier method returns the expected type."""
     res = strategy_instance.get_identifier()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(
             results=res,
             expected_types=["schema:Text", "schema:URL", "schema:PropertyValue"],
@@ -97,6 +106,7 @@ def test_get_citation_returns_expected_type(strategy_instance):
     """Test that the get_citation method returns the expected type."""
     res = strategy_instance.get_citation()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Text", "schema:CreativeWork"])
 
 
@@ -104,6 +114,7 @@ def test_get_variable_measured_returns_expected_type(strategy_instance):
     """Test that the get_variable_measured method returns the expected type."""
     res = strategy_instance.get_variable_measured()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:PropertyValue"])
 
 
@@ -120,6 +131,7 @@ def test_get_included_in_data_catalog_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_included_in_data_catalog()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:DataCatalog"])
 
 
@@ -140,6 +152,7 @@ def test_get_subject_of_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_subject_of()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:DataDownload"])
 
 
@@ -147,6 +160,7 @@ def test_get_distribution_returns_expected_type(strategy_instance):
     """Test that the get_distribution method returns the expected type."""
     res = strategy_instance.get_distribution()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:DataDownload"])
 
 
@@ -215,6 +229,7 @@ def test_get_potential_action_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_potential_action()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:SearchAction"])
 
 
@@ -222,6 +237,7 @@ def test_get_date_created_returns_expected_type(strategy_instance):
     """Test that the get_date_created method returns the expected type."""
     res = strategy_instance.get_date_created()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Date", "schema:DateTime"])
 
 
@@ -229,6 +245,7 @@ def test_get_date_modified_returns_expected_type(strategy_instance):
     """Test that the get_date_modified method returns the expected type."""
     res = strategy_instance.get_date_modified()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Date", "schema:DateTime"])
 
 
@@ -236,6 +253,7 @@ def test_get_date_published_returns_expected_type(strategy_instance):
     """Test that the get_date_published method returns the expected type."""
     res = strategy_instance.get_date_published()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Date", "schema:DateTime"])
 
 
@@ -244,6 +262,7 @@ def test_get_expires_returns_expected_type(strategy_instance):
     strategy_instance.kwargs = {"expires": "2019-06-12T14:44:15Z"}
     res = strategy_instance.get_expires()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Date", "schema:DateTime"])
 
 
@@ -251,6 +270,7 @@ def test_get_temporal_coverage_returns_expected_type(strategy_instance):
     """Test that the get_temporal_coverage method returns the expected type."""
     res = strategy_instance.get_temporal_coverage()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(
             results=res,
             expected_types=[
@@ -267,6 +287,7 @@ def test_get_spatial_coverage_returns_expected_type(strategy_instance):
     """Test that the get_spatial_coverage method returns the expected type."""
     res = strategy_instance.get_spatial_coverage()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Place"])
 
 
@@ -274,6 +295,7 @@ def test_get_creator_returns_expected_type(strategy_instance):
     """Test that the get_creator method returns the expected type."""
     res = strategy_instance.get_creator()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(
             results=res,
             expected_types=["schema:Person", "schema:Organization", "schema:Role"],
@@ -284,6 +306,7 @@ def test_get_contributor_returns_expected_type(strategy_instance):
     """Test that the get_contributor method returns the expected type."""
     res = strategy_instance.get_contributor()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(
             results=res,
             expected_types=["schema:Person", "schema:Organization", "schema:Role"],
@@ -297,6 +320,7 @@ def test_get_provider_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_provider()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Organization", "@id"])
 
 
@@ -307,6 +331,7 @@ def test_get_publisher_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_publisher()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:Organization", "@id"])
 
 
@@ -314,6 +339,7 @@ def test_get_funding_returns_expected_type(strategy_instance):
     """Test that the get_funding method returns the expected type."""
     res = strategy_instance.get_funding()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:MonetaryGrant"])
 
 
@@ -321,6 +347,7 @@ def test_get_license_returns_expected_type(strategy_instance):
     """Test that the get_license method returns the expected type."""
     res = strategy_instance.get_license()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["schema:URL"])
 
 
@@ -328,6 +355,7 @@ def test_get_was_revision_of_returns_expected_type(strategy_instance):
     """Test that the get_was_revision_of method returns the expected type."""
     res = strategy_instance.get_was_revision_of()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["@id"])
 
 
@@ -335,6 +363,7 @@ def test_get_was_derived_from_returns_expected_type(strategy_instance):
     """Test that the get_was_derived_from method returns the expected type."""
     res = strategy_instance.get_was_derived_from()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["@id"])
 
 
@@ -342,6 +371,7 @@ def test_get_is_based_on_returns_expected_type(strategy_instance):
     """Test that the get_is_based_on method returns the expected type."""
     res = strategy_instance.get_is_based_on()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["@id"])
 
 
@@ -358,4 +388,5 @@ def test_get_was_generated_by_returns_expected_type(strategy_instance):
     }
     res = strategy_instance.get_was_generated_by()
     if res is not None:
+        assert is_not_null(res)
         assert is_property_type(res, ["provone:Execution"])


### PR DESCRIPTION
Ensure that strategy methods return a None value instead of an null (empty) value or container. None values are interpreted in the final graph cleaning step of main.convert as properties with no meaningful information, which should be removed from the resulting SOSO graph before being returned to the user.