### PR TITLE
feat: apply rm_null_values to strategy methods

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -3,6 +3,7 @@
 from mimetypes import guess_type
 from lxml import etree
 from soso.interface import StrategyInterface
+from soso.utilities import rm_null_values
 
 
 class EML(StrategyInterface):
@@ -51,27 +52,27 @@ class EML(StrategyInterface):
 
     def get_name(self):
         name = self.metadata.xpath(".//dataset/title")
-        return name[0].text
+        return rm_null_values(name[0].text)
 
     def get_description(self):
         description = self.metadata.xpath(".//dataset/abstract")
-        return description[0].text
+        return rm_null_values(description[0].text)
 
     def get_url(self):
         url = self.kwargs.get("url")
-        return url
+        return rm_null_values(url)
 
     def get_same_as(self):
         same_as = self.kwargs.get("sameAs")
-        return same_as
+        return rm_null_values(same_as)
 
     def get_version(self):
         version = self.kwargs.get("version")
-        return version
+        return rm_null_values(version)
 
     def get_is_accessible_for_free(self):
         is_accessible_for_free = self.kwargs.get("isAccessibleForFree")
-        return is_accessible_for_free
+        return rm_null_values(is_accessible_for_free)
 
     def get_keywords(self):
         keywords = []
@@ -84,15 +85,15 @@ class EML(StrategyInterface):
                 "url": item.text,
             }
             keywords.append(defined_term)
-        return keywords
+        return rm_null_values(keywords)
 
     def get_identifier(self):
         identifier = self.metadata.xpath("@packageId")
-        return identifier[0]
+        return rm_null_values(identifier[0])
 
     def get_citation(self):
         citation = self.kwargs.get("citation")
-        return citation
+        return rm_null_values(citation)
 
     def get_variable_measured(self):
         variable_measured = []
@@ -112,15 +113,15 @@ class EML(StrategyInterface):
                 key: value for key, value in property_value.items() if value is not None
             }
             variable_measured.append(property_value)
-        return variable_measured
+        return rm_null_values(variable_measured)
 
     def get_included_in_data_catalog(self):
         included_in_data_catalog = self.kwargs.get("includedInDataCatalog")
-        return included_in_data_catalog
+        return rm_null_values(included_in_data_catalog)
 
     def get_subject_of(self):
         subject_of = self.kwargs.get("subjectOf")
-        return subject_of
+        return rm_null_values(subject_of)
 
     def get_distribution(self):
         distribution = []
@@ -143,27 +144,27 @@ class EML(StrategyInterface):
                     "encodingFormat": get_data_entity_encoding_format(item),
                 }
                 distribution.append(data_download)
-        return distribution
+        return rm_null_values(distribution)
 
     def get_potential_action(self):
         potential_action = self.kwargs.get("potentialAction")
-        return potential_action
+        return rm_null_values(potential_action)
 
     def get_date_created(self):
         date_created = self.kwargs.get("dateCreated")
-        return date_created
+        return rm_null_values(date_created)
 
     def get_date_modified(self):
         date_modified = self.metadata.xpath(".//dataset/pubDate")
-        return date_modified[0].text
+        return rm_null_values(date_modified[0].text)
 
     def get_date_published(self):
         date_published = self.metadata.xpath(".//dataset/pubDate")
-        return date_published[0].text
+        return rm_null_values(date_published[0].text)
 
     def get_expires(self):
         expires = self.kwargs.get("expires")
-        return expires
+        return rm_null_values(expires)
 
     def get_temporal_coverage(self):
         range_of_dates = self.metadata.xpath(
@@ -182,7 +183,7 @@ class EML(StrategyInterface):
                 temporal_coverage = None
             else:
                 temporal_coverage = convert_single_date_time(single_date_time[0])
-        return temporal_coverage
+        return rm_null_values(temporal_coverage)
 
     def get_spatial_coverage(self):
         geo = []
@@ -195,7 +196,7 @@ class EML(StrategyInterface):
             elif object_type == "Polygon":
                 geo.append(get_polygon(item))
         spatial_coverage = {"@type": "Place", "geo": geo}
-        return spatial_coverage
+        return rm_null_values(spatial_coverage)
 
     def get_creator(self):
         creator = []
@@ -206,7 +207,7 @@ class EML(StrategyInterface):
             creator = {"@list": creator}  # to preserve order
         else:
             creator = None  # for readability
-        return creator
+        return rm_null_values(creator)
 
     def get_contributor(self):
         contributor = []
@@ -222,15 +223,15 @@ class EML(StrategyInterface):
             contributor = {"@list": contributor}  # to preserve order
         else:
             contributor = None  # for readability
-        return contributor
+        return rm_null_values(contributor)
 
     def get_provider(self):
         provider = self.kwargs.get("provider")
-        return provider
+        return rm_null_values(provider)
 
     def get_publisher(self):
         publisher = self.kwargs.get("publisher")
-        return publisher
+        return rm_null_values(publisher)
 
     def get_funding(self):
         funding = []
@@ -248,15 +249,15 @@ class EML(StrategyInterface):
             }
             funding.append(res)
         funding = None if len(funding) == 0 else funding  # for readability
-        return funding
+        return rm_null_values(funding)
 
     def get_license(self):
         license_url = self.metadata.findtext(".//dataset/licensed/url")
-        return license_url
+        return rm_null_values(license_url)
 
     def get_was_revision_of(self):
         was_revision_of = self.kwargs.get("wasRevisionOf")
-        return was_revision_of
+        return rm_null_values(was_revision_of)
 
     def get_was_derived_from(self):
         was_derived_from = []
@@ -267,15 +268,15 @@ class EML(StrategyInterface):
                 was_derived_from.append({"@id": url})
         if len(was_derived_from) == 0:
             was_derived_from = None  # for readability
-        return was_derived_from
+        return rm_null_values(was_derived_from)
 
     def get_is_based_on(self):
         is_based_on = self.get_was_derived_from()  # duplicate for discovery
-        return is_based_on
+        return rm_null_values(is_based_on)
 
     def get_was_generated_by(self):
         was_generated_by = self.kwargs.get("wasGeneratedBy")
-        return was_generated_by
+        return rm_null_values(was_generated_by)
 
 
 # Below are utility functions for the EML strategy.


### PR DESCRIPTION
Implement the rm_null_values function to remove null values from the results of strategy methods before returning them to the client. This approach is recommended for strategy methods rather than main.convert to enable the direct usage of strategy methods and their results. For instance, this facilitates updating specific graph properties when a new algorithm is implemented without needing to recreate the entire dataset graph.