### PR TITLE
docs: define "null" in rm_null_values function

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -132,6 +132,16 @@ def rm_null_values(res):
     Any
         The results with all null values removed. None is returned if all
         values are null.
+
+    Notes
+    -----
+    Null values are defined as follows:
+    
+    - None
+    - An empty string
+    - An empty list
+    - An empty dictionary
+    - A dictionary with only one key, "@type"
     """
 
     def is_null(value):

--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -136,7 +136,7 @@ def rm_null_values(res):
     Notes
     -----
     Null values are defined as follows:
-    
+
     - None
     - An empty string
     - An empty list


### PR DESCRIPTION
Add a definition of what constitutes a "null" value in the rm_null_values function documentation. This clarification ensures that users can easily understand the concept without needing to inspect the code.