### PR TITLE
refactor: fix typo

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -73,7 +73,7 @@ def test_get_version_returns_expected_type(strategy_instance):
             assert is_property_type(res, ["schema:Text", "schema:Number"])
 
 
-def test_get_get_is_accessible_for_free_returns_expected_type(strategy_instance):
+def test_get_is_accessible_for_free_returns_expected_type(strategy_instance):
     """Test that the get_is_accessible_for_free method returns the expected
     type."""
     strategy_instance.kwargs = {"isAccessibleForFree": True}


### PR DESCRIPTION
Remove a duplicate word from the test name to enhance cleanliness and readability.