### PR TITLE
feat: get encoding format of EML record

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -663,3 +663,20 @@ def get_person_or_organization(responsible_party):
             "identifier": convert_user_id(responsible_party.xpath("userId")),
         }
     return res
+
+
+def get_encoding_format(metadata):
+    """
+    Parameters
+    ----------
+    metadata : object or None
+        The metadata object as an XML tree.
+
+    Returns
+    -------
+    str
+        The encoding format of an EML metadata record.
+    """
+    schema_location = metadata.getroot().nsmap.get('eml', None)
+    encoding_format = ["application/xml", schema_location]
+    return encoding_format

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -677,6 +677,6 @@ def get_encoding_format(metadata):
     str
         The encoding format of an EML metadata record.
     """
-    schema_location = metadata.getroot().nsmap.get('eml', None)
+    schema_location = metadata.getroot().nsmap.get("eml", None)
     encoding_format = ["application/xml", schema_location]
     return encoding_format

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -14,7 +14,10 @@ from soso.strategies.eml import (
     convert_user_id,
     get_data_entity_encoding_format,
     get_person_or_organization,
+    get_encoding_format,
+    EML,
 )
+from soso.utilities import get_example_metadata_file_path
 
 
 def test_get_content_url_returns_expected_value():
@@ -462,3 +465,12 @@ def test_get_person_or_organization_returns_value_and_type():
     res = get_person_or_organization(root)
     assert isinstance(res, dict)
     assert res["@type"] == "Organization"
+
+
+def test_get_encoding_format():
+    """Test that the get_encoding_format function returns the expected
+    value."""
+    eml = EML(file=get_example_metadata_file_path("EML"))
+    res = get_encoding_format(metadata=eml.metadata)
+    expected = ["application/xml", "https://eml.ecoinformatics.org/eml-2.2.0"]
+    assert res == expected


### PR DESCRIPTION
Add a helper function to retrieve the encoding format of an EML file for use in the subjectOf property.