### PR TITLE
docs: note unmappable property for CRS

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -45,6 +45,9 @@ class EML(StrategyInterface):
     - publisher
     - wasRevisionOf
     - wasGeneratedBy
+    - additionalProperty - This property is nested within the spatialCoverage
+      property, and can be used to declare the coordinate reference system
+      of the spatial coverage. The default is WGS84.
     """
 
     def __init__(self, file, **kwargs):


### PR DESCRIPTION
Add a note about the unmappable property for specifying coordinate reference systems (CRS) to the spatialCoverage property. This addition alerts users to the ability to customize.