### PR TITLE
test: fix typo in test code

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,9 +9,6 @@ def test_convert_returns_str(strategy_names):
     """Test that the convert function returns a string."""
     for strategy in strategy_names:
         res = convert(file=get_example_metadata_file_path(strategy), strategy=strategy)
-        # Write to file for debugging
-        with open("tests/data/" + strategy + ".json", "w", encoding="utf-8") as file:
-            file.write(res)
         assert isinstance(res, str)
 
 


### PR DESCRIPTION
Remove a misplaced file writing block from one of the tests to prevent writing a file when the test is executed. This code block was accidentally committed in: 88e956febf0f8d55bdd019af50df9cac14219b02