### PR TITLE
docs: remove short list of features

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,13 +38,6 @@ Not all SOSO properties are present in the metadata. To include these, use metho
     >>> r
     '{"@context": {"@vocab": "https://schema.org/", "prov": "http://www. ...}'
 
-Features
---------
-
-* Convert common metadata standards to SOSO.
-* Customize for unique use cases.
-
-
 The User Guide
 --------------
 


### PR DESCRIPTION
Temporarily remove the features section from the documentation until there are enough features to warrant a list.