### PR TITLE
docs: add basic usage to the quickstart guide

### DIFF
--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -16,4 +16,15 @@ Once pip is installed, you can install `soso` by running the following command i
 
 
 
-[TODO: Demonstrate the core functionalities of this package.]
+
+Metadata Conversion
+-------------------
+
+The primary function is to convert metadata records into SOSO markup. To perform a conversion, specify the file path of the metadata and the desired conversion strategy. Each metadata standard corresponds to a specific strategy.
+
+    >>> from soso.main import convert
+    >>> r = convert(file='metadata.xml', strategy='eml')
+    >>> r
+    '{"@context": {"@vocab": "https://schema.org/", "prov": "http://www. ...}'
+
+For a list of available strategies, please refer to the documentation of the `main.convert` function.


### PR DESCRIPTION
Include a basic usage example in the quickstart guide to help users get started quickly with the package.