### PR TITLE
docs: eliminate redundant statement

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -215,8 +215,6 @@ Allowing users to define properties in this manner is simpler than requiring the
 
 Some implementation notes on creating a property using this approach:
 
-Some implementation notes:
-
 * Include the parameter in the strategy docstrings, preferably using the SOSO property name for clarity.
 * Specify the input type of the parameter as `Any` to accommodate various input types the property may have.
 * Define the target SOSO property created through this parameter to avoid confusion with similarly named properties elsewhere in the SOSO schema.


### PR DESCRIPTION
Remove a redundant statement from the design documents. This originated at: 9f25733a0b0b7c1a22a189698ef5a4a9b6aa5020.