### PR TITLE
test: instantiate strategy with parameters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,9 @@ def strategy_names():
 def strategy_instance(request):
     """Return the strategy instances."""
     if request.param is EML:
-        res = request.param(file=get_example_metadata_file_path("EML"))
+        res = request.param(
+            file=get_example_metadata_file_path("EML"), **get_kwargs("eml")
+        )
     return res
 
 
@@ -262,3 +264,20 @@ def is_not_null(results):
             else:
                 res.append(len(result) > 0)
     return any(res)
+
+
+def get_kwargs(strategy=None):
+    """
+    Parameters
+    ----------
+    strategy : str
+        The strategy name.
+
+    Returns
+    -------
+    dict
+        A dictionary of keyword arguments.
+    """
+    if strategy == "eml":
+        return {}
+    return {}

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -3,6 +3,7 @@
 from tests.conftest import is_url
 from tests.conftest import is_property_type
 from tests.conftest import is_not_null
+from tests.conftest import get_kwargs
 
 
 def test_is_url():
@@ -130,3 +131,12 @@ def test_is_not_null_for_non_dictionaries():
     assert is_not_null("") is False  # schema:Text & schema:URL
     assert is_not_null(None) is False  # schema:Number & schema:Boolean
     assert is_not_null([]) is False  # List
+
+
+def test_get_kwargs():
+    """Test that the get_kwargs function returns a dictionary for a given
+    strategy."""
+    kwargs = get_kwargs("eml")  # for a specific strategy
+    assert isinstance(kwargs, dict)
+    kwargs = get_kwargs()  # for a default strategy
+    assert isinstance(kwargs, dict)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 from json import loads
 from soso.main import convert
 from soso.utilities import get_example_metadata_file_path
+from tests.conftest import get_kwargs
 
 
 def test_convert_returns_str(strategy_names):
@@ -15,7 +16,11 @@ def test_convert_returns_str(strategy_names):
 def test_convert_returns_json(strategy_names):
     """Test that the convert function returns valid JSON."""
     for strategy in strategy_names:
-        res = convert(file=get_example_metadata_file_path(strategy), strategy=strategy)
+        res = convert(
+            file=get_example_metadata_file_path(strategy),
+            strategy=strategy,
+            **get_kwargs(strategy)
+        )
         assert isinstance(loads(res), dict)
 
 
@@ -49,6 +54,8 @@ def test_convert_verify_strategy_results(strategy_names):
         with open("tests/data/" + strategy + ".json", "r", encoding="utf-8") as file:
             expected_results = file.read()
             res = convert(
-                file=get_example_metadata_file_path(strategy), strategy=strategy
+                file=get_example_metadata_file_path(strategy),
+                strategy=strategy,
+                **get_kwargs(strategy)
             )
             assert res == expected_results


### PR DESCRIPTION
Create a utility test function (`get_kwargs`) to help instantiate strategies with parameters. Add this to the strategy instance to enable both unit and integration tests. This simulates use of parameters by clients to create otherwise unmappable properties.