### PR TITLE
ci: ignore Pylint 'too many arguments'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ remove_dist = false                         # don't remove dists
 patch_without_tag = false                    # patch release by default
 
 [tool.pylint.'MESSAGES.CONTROL']
-disable = "too-many-public-methods,c-extension-no-member"
+disable = "too-many-public-methods,c-extension-no-member,too-many-arguments"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Ignore Pylint's `Too many arguments (R0913)` warning to simplify the creation of unmappable properties via class parameters.