### PR TITLE
ci: ignore Pylint too-many-instance-attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ remove_dist = false                         # don't remove dists
 patch_without_tag = false                    # patch release by default
 
 [tool.pylint.'MESSAGES.CONTROL']
-disable = "too-many-public-methods,c-extension-no-member,too-many-arguments"
+disable = "too-many-public-methods,c-extension-no-member,too-many-arguments,too-many-instance-attributes"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Ignore Pylint's too-many-instance-attributes (R0902) warning to simplify the creation of unmappable properties via class parameters.