### PR TITLE
refactor: use type hints for static code analysis

### DIFF
--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -1,4 +1,5 @@
 """The strategy interface module."""
+from typing import Any
 
 
 class StrategyInterface:
@@ -23,7 +24,7 @@ class StrategyInterface:
         returned for 'NULL' values.
     """
 
-    def __init__(self, metadata=None, **kwargs):
+    def __init__(self, metadata: Any = None, **kwargs: dict):
         """Return the strategy attributes."""
         self.metadata = metadata
         self.kwargs = kwargs

--- a/src/soso/main.py
+++ b/src/soso/main.py
@@ -5,7 +5,7 @@ from soso.strategies.eml import EML
 from soso.utilities import delete_unused_vocabularies
 
 
-def convert(file, strategy, **kwargs):
+def convert(file: str, strategy: str, **kwargs: dict) -> str:
     """Return SOSO markup for a metadata file and specified strategy.
 
     Parameters

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -1,6 +1,7 @@
 """The EML strategy module."""
 
 from mimetypes import guess_type
+from typing import Union
 from lxml import etree
 from soso.interface import StrategyInterface
 from soso.utilities import delete_null_values
@@ -49,7 +50,7 @@ class EML(StrategyInterface):
       of the spatial coverage. The default is WGS84.
     """
 
-    def __init__(self, file, **kwargs):
+    def __init__(self, file: str, **kwargs: dict):
         """Initialize the strategy."""
         super().__init__(metadata=etree.parse(file))
         self.kwargs = kwargs
@@ -301,7 +302,7 @@ class EML(StrategyInterface):
 # Below are utility functions for the EML strategy.
 
 
-def get_content_size(data_entity_element):
+def get_content_size(data_entity_element: etree._Element) -> str:
     """Return the content size for a data entity element.
 
     The If the "unit" attribute of the "size" element is defined, it will be
@@ -324,7 +325,7 @@ def get_content_size(data_entity_element):
     return size
 
 
-def get_content_url(data_entity_element):
+def get_content_url(data_entity_element: etree._Element) -> Union[str, None]:
     """Return the content url for a data entity element.
 
     If the "function" attribute of the data entity element is "information",
@@ -346,7 +347,7 @@ def get_content_url(data_entity_element):
     return None
 
 
-def convert_range_of_dates(range_of_dates):
+def convert_range_of_dates(range_of_dates: etree._Element) -> Union[str, dict]:
     """Return EML rangeOfDates as a calendar datetime or geologic age interval.
 
     Parameters
@@ -376,7 +377,7 @@ def convert_range_of_dates(range_of_dates):
     return interval
 
 
-def convert_single_date_time(single_date_time):
+def convert_single_date_time(single_date_time: etree._Element) -> Union[str, dict]:
     """Return EML singleDateTime as a calendar datetime or geologic age
     instant.
 
@@ -395,7 +396,7 @@ def convert_single_date_time(single_date_time):
     return convert_single_date_time_type(single_date_time)
 
 
-def convert_single_date_time_type(single_date_time):
+def convert_single_date_time_type(single_date_time: etree._Element) -> Union[str, dict]:
     """Convert EML SingleDateTimeType to a calendar datetime or geologic age
     instant.
 
@@ -446,7 +447,7 @@ def convert_single_date_time_type(single_date_time):
     return instant
 
 
-def get_spatial_type(geographic_coverage):
+def get_spatial_type(geographic_coverage: etree._Element) -> str:
     """Return the object type for a geographic coverage element.
 
     Parameters
@@ -478,7 +479,7 @@ def get_spatial_type(geographic_coverage):
     return spatial_type
 
 
-def get_point(geographic_coverage):
+def get_point(geographic_coverage: etree._Element) -> dict:
     """Return the geographic coverage as a point.
 
     Parameters
@@ -510,7 +511,7 @@ def get_point(geographic_coverage):
     return point
 
 
-def get_elevation(geographic_coverage):
+def get_elevation(geographic_coverage: etree._Element) -> Union[str, None]:
     """Return the elevation for a geographic coverage element.
 
     Parameters
@@ -537,7 +538,7 @@ def get_elevation(geographic_coverage):
     return elevation
 
 
-def get_box(geographic_coverage):
+def get_box(geographic_coverage: etree._Element) -> dict:
     """Return the geographic coverage as a box.
 
     Parameters
@@ -564,7 +565,7 @@ def get_box(geographic_coverage):
     return box
 
 
-def get_polygon(geographic_coverage):
+def get_polygon(geographic_coverage: etree._Element) -> dict:
     """Return the geographic coverage as a polygon.
 
     Parameters
@@ -605,7 +606,7 @@ def get_polygon(geographic_coverage):
     return polygon
 
 
-def convert_user_id(user_id):
+def convert_user_id(user_id: list) -> Union[dict, None]:
     """Return the user ID as a PropertyValue.
 
     Parameters
@@ -629,7 +630,7 @@ def convert_user_id(user_id):
     return property_value
 
 
-def get_data_entity_encoding_format(data_entity_element):
+def get_data_entity_encoding_format(data_entity_element: etree._Element) -> str:
     """Return the encoding format for a data entity element.
 
     Parameters
@@ -647,7 +648,7 @@ def get_data_entity_encoding_format(data_entity_element):
     return encoding_format[0]
 
 
-def get_person_or_organization(responsible_party):
+def get_person_or_organization(responsible_party: etree._Element) -> dict:
     """Return the responsible party as a schema:Person or schema:Organization.
 
     The Person and Organization types are very similar, so this function
@@ -681,7 +682,7 @@ def get_person_or_organization(responsible_party):
     return res
 
 
-def get_encoding_format(metadata):
+def get_encoding_format(metadata: etree.ElementTree) -> str:
     """
     Parameters
     ----------
@@ -698,7 +699,7 @@ def get_encoding_format(metadata):
     return encoding_format
 
 
-def get_methods(xml):
+def get_methods(xml: etree._Element) -> Union[str, None]:
     """
     Parameters
     ----------
@@ -719,7 +720,7 @@ def get_methods(xml):
     return methods
 
 
-def get_checksum(data_entity_element):
+def get_checksum(data_entity_element: etree._Element) -> Union[list, None]:
     """
     Parameters
     ----------

--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -4,13 +4,15 @@ import urllib.error
 from importlib import resources
 from numbers import Number
 from json import dumps
+import pathlib
+from typing import Any, Union
 import warnings
 import pyshacl.validate
 import pandas as pd
 import requests
 
 
-def validate(graph):
+def validate(graph: str) -> bool:
     """Validate a graph against the SOSO dataset SHACL shape.
 
     Parameters
@@ -61,7 +63,7 @@ def get_shacl_file_path():
     return file_path
 
 
-def get_sssom_file_path(strategy):
+def get_sssom_file_path(strategy: str) -> pathlib.PosixPath:
     """Return the SSSOM file path for the specified strategy.
 
     Parameters
@@ -79,7 +81,7 @@ def get_sssom_file_path(strategy):
     return file_path
 
 
-def get_example_metadata_file_path(strategy):
+def get_example_metadata_file_path(strategy: str) -> pathlib.PosixPath:
     """Return the file path of an example metadata file.
 
     Parameters
@@ -99,7 +101,7 @@ def get_example_metadata_file_path(strategy):
     return file_path
 
 
-def read_sssom(strategy):
+def read_sssom(strategy: str) -> pd.DataFrame:
     """Return the SSSOM for the specified strategy.
 
     Parameters
@@ -117,7 +119,7 @@ def read_sssom(strategy):
     return sssom
 
 
-def delete_null_values(res):
+def delete_null_values(res: Any) -> Any:
     """
     Remove null values from results returned by strategy methods. This
     function is to help developers of strategy methods clean their results
@@ -146,7 +148,7 @@ def delete_null_values(res):
     - A dictionary with only one key, "@type"
     """
 
-    def is_null(value):
+    def is_null(value: Any) -> bool:
         """
         Parameters
         ----------
@@ -168,7 +170,7 @@ def delete_null_values(res):
             )
         )
 
-    def deep_clean(data):
+    def deep_clean(data: Any) -> Any:
         """
         Parameters
         ----------
@@ -217,7 +219,7 @@ def delete_null_values(res):
     return cleaned_data
 
 
-def delete_unused_vocabularies(graph):
+def delete_unused_vocabularies(graph: dict) -> dict:
     """Delete unused vocabularies from the top level JSON-LD @context. This
     function is to help clean the graph created by `main.convert` before
     returning it to the user.
@@ -246,7 +248,7 @@ def delete_unused_vocabularies(graph):
     return graph
 
 
-def generate_citation_from_doi(url, style, locale):
+def generate_citation_from_doi(url: str, style: str, locale: str) -> Union[str, None]:
     """
     Generates a citation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Configure the test suite."""
 import socket
+from typing import Any
+import pathlib
 from urllib.parse import urlparse
 from numbers import Number
 from copy import deepcopy
@@ -9,13 +11,13 @@ from soso.utilities import get_example_metadata_file_path
 
 
 @pytest.fixture
-def strategy_names():
+def strategy_names() -> list:
     """Return the names of available strategies."""
     return ["eml"]
 
 
 @pytest.fixture(params=[EML])
-def strategy_instance(request):
+def strategy_instance(request) -> pathlib.PosixPath:
     """Return the strategy instances."""
     if request.param is EML:
         res = request.param(file=get_example_metadata_file_path("EML"))
@@ -23,7 +25,7 @@ def strategy_instance(request):
 
 
 @pytest.fixture
-def soso_properties():
+def soso_properties() -> list:
     """Return the names of SOSO properties."""
     return [
         "@context",
@@ -62,7 +64,7 @@ def soso_properties():
 
 
 @pytest.fixture
-def interface_methods():
+def interface_methods() -> list:
     """Return the names of strategy methods."""
     res = [
         "get_name",
@@ -116,7 +118,7 @@ def internet_connection():
         return False
 
 
-def is_url(url):
+def is_url(url: str):
     """Check if a string is a URL."""
     try:
         res = urlparse(url)
@@ -125,7 +127,7 @@ def is_url(url):
         return False
 
 
-def is_property_type(results, expected_types):
+def is_property_type(results: Any, expected_types: list) -> bool:
     """
     Parameters
     ----------
@@ -215,7 +217,7 @@ def is_property_type(results, expected_types):
     return any(res)
 
 
-def is_not_null(results):
+def is_not_null(results: Any) -> bool:
     """
     Parameters
     ----------


### PR DESCRIPTION
Integrate type hints to support static code analysis. Apply to all APIs, not just the public-facing API. Utilize union types for functions with variable inputs/outputs when the list is not too long; otherwise, use Any. Remove type definitions in docstrings to maintain DRY (Don't Repeat Yourself) principles.