### PR TITLE
refactor: exception handling for EML file types

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -47,6 +47,9 @@ class EML(StrategyInterface):
 
     def __init__(self, file: str, **kwargs: dict):
         """Initialize the strategy."""
+        file = str(file)  # incase file is a Path object
+        if not file.endswith(".xml"):  # file should be XML
+            raise ValueError(file + " must be an XML file.")
         super().__init__(metadata=etree.parse(file))
         self.kwargs = kwargs
 

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -1,5 +1,6 @@
 """Test additional EML module functions and methods."""
 
+from importlib import resources
 from lxml import etree
 from soso.strategies.eml import (
     get_content_url,
@@ -543,3 +544,12 @@ def test_get_checksum():
     root = etree.fromstring(xml_content)
     assert isinstance(get_checksum(root), list)
     assert len(get_checksum(root)) == 2
+
+
+def test_eml_file_input_must_be_xml():
+    """Test that the EML() class raises an error if the file input is not XML."""
+    not_xml = resources.files("soso.data").joinpath("soso-eml.sssom.tsv")
+    try:
+        EML(file=not_xml)
+    except ValueError as error:
+        assert "must be an XML file" in str(error)


### PR DESCRIPTION
Raise informative exceptions for file parsing failures by the EML strategy. Currently, non-XML files input to the EML strategy result in cryptic messages raised by `lxml.etree.parse`. Wrap this operation in exception management clauses that check for the expected file type, estimated by the file extension.

Note we may want to go a step further and verify that the file is EML.