### PR TITLE
test: use empty metadata for testing negative cases

### DIFF
--- a/src/soso/data/eml_empty.xml
+++ b/src/soso/data/eml_empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eml>
+</eml>

--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -79,6 +79,19 @@ def get_example_metadata_file_path(strategy: str) -> pathlib.PosixPath:
     return file_path
 
 
+def get_empty_metadata_file_path(strategy: str) -> pathlib.PosixPath:
+    """
+    :param strategy: Metadata strategy. Can be: EML.
+
+    :returns:   File path of an empty metadata file.
+    """
+    if strategy.lower() == "eml":
+        file_path = resources.files("soso.data").joinpath("eml_empty.xml")
+    else:
+        raise ValueError("Invalid choice!")
+    return file_path
+
+
 def read_sssom(strategy: str) -> pd.DataFrame:
     """Return the SSSOM for the specified strategy.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from numbers import Number
 from copy import deepcopy
 import pytest
 from soso.strategies.eml import EML
-from soso.utilities import get_example_metadata_file_path
+from soso.utilities import get_example_metadata_file_path, get_empty_metadata_file_path
 
 
 @pytest.fixture
@@ -25,6 +25,17 @@ def strategy_instance(request) -> pathlib.PosixPath:
     """
     if request.param is EML:
         res = request.param(file=get_example_metadata_file_path("EML"))
+    return res
+
+
+@pytest.fixture(params=[EML])
+def strategy_instance_no_meta(request) -> pathlib.PosixPath:
+    """
+    :returns:   The strategy instances parameterized with an empty metadata
+                file. This is useful for testing negative cases.
+    """
+    if request.param is EML:
+        res = request.param(file=get_empty_metadata_file_path("EML"))
     return res
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,7 +8,7 @@ from pandas import DataFrame
 from soso.utilities import validate
 from soso.utilities import get_sssom_file_path
 from soso.utilities import read_sssom
-from soso.utilities import get_example_metadata_file_path
+from soso.utilities import get_example_metadata_file_path, get_empty_metadata_file_path
 from soso.utilities import get_shacl_file_path
 from soso.utilities import delete_null_values
 from soso.utilities import delete_unused_vocabularies
@@ -78,6 +78,13 @@ def test_get_example_metadata_file_path_returns_path(strategy_names):
     """Test that get_example_metadata returns a path."""
     for strategy in strategy_names:
         file_path = get_example_metadata_file_path(strategy=strategy)
+        assert isinstance(file_path, PosixPath)
+
+
+def test_get_empty_metadata_file_path_returns_path(strategy_names):
+    """Test that get_empty_metadata_file_path returns a path."""
+    for strategy in strategy_names:
+        file_path = get_empty_metadata_file_path(strategy=strategy)
         assert isinstance(file_path, PosixPath)
 
 


### PR DESCRIPTION
Create an empty metadata file for each strategy to test the negative cases, i.e. where expected metadata content is missing. Currently, only the positive cases are tested, where the test metadata file contains all the elements mappable from the metadata standard to SOSO.