### PR TITLE
fix: don't list nested properties as "unmappable"

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -40,9 +40,6 @@ class EML(StrategyInterface):
             - publisher
             - prov:wasRevisionOf
             - prov:wasGeneratedBy
-            - additionalProperty - This property is nested within the spatialCoverage
-              property, and can be used to declare the coordinate reference system
-              of the spatial coverage. The default is WGS84.
     """
 
     def __init__(self, file: str, **kwargs: dict):


### PR DESCRIPTION
Remove `additionalProperty`, nested within `schema:spatialCoverage`, from the list of unmappable properties for the EML strategy. We have defined unmappable properties as top-level properties that cannot be meaningfully mapped to the target metadata standard. In this case, the nested property doesn't meet this criteria.

The initial rationale behind allowing users to define nested properties as arguments to the `main.convert` method was to simplify this process. After some experience, it became evident that many nested properties meet this criteria within the EML metadata standard. Scaling this out to other metadata standards would create an overly complicated code base and likely more confusion than it's worth.