### PR TITLE
feat: make 'file' argument accessible to strategy methods

### DIFF
--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -11,6 +11,9 @@ class StrategyInterface:
             another suitable representation. This object is utilized by
             strategy methods to generate SOSO properties. (Any)
 
+        file:
+            The path to the metadata file. (str)
+
         kwargs:
             Additional keyword arguments for passing information to the chosen
             `strategy`. This can help in the case of unmappable properties.
@@ -18,9 +21,10 @@ class StrategyInterface:
             information. (dict or None)
     """
 
-    def __init__(self, metadata: Any = None, **kwargs: dict):
+    def __init__(self, metadata: Any = None, file: str = None, **kwargs: dict):
         """Return the strategy attributes."""
         self.metadata = metadata
+        self.file = file
         self.kwargs = kwargs
 
     def get_name(self):

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -48,6 +48,7 @@ class EML(StrategyInterface):
         if not file.endswith(".xml"):  # file should be XML
             raise ValueError(file + " must be an XML file.")
         super().__init__(metadata=etree.parse(file))
+        self.file = file
         self.kwargs = kwargs
 
     def get_name(self) -> Union[str, None]:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -8,6 +8,11 @@ def test_interface_has_metadata_attribute():
     assert hasattr(StrategyInterface(), "metadata")
 
 
+def test_interface_has_file_attribute():
+    """Test that the StrategyInterface class has a file attribute."""
+    assert hasattr(StrategyInterface(), "file")
+
+
 def test_interface_has_kwargs_attribute():
     """Test that the StrategyInterface class has a kwargs attribute."""
     assert hasattr(StrategyInterface(), "kwargs")


### PR DESCRIPTION
Make the 'file' argument, passed to the strategy class, accessible to strategy methods by adding it to the list of class attributes. The file path may contain useful metadata.