### PR TITLE
docs: remove unused advanced section

### DIFF
--- a/docs/source/_templates/sidebarintro.html
+++ b/docs/source/_templates/sidebarintro.html
@@ -16,7 +16,6 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="https://soso.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
-  <li><a href="https://soso.readthedocs.io/en/latest/user/advanced.html">Advanced Usage</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/user/api.html">API Reference</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/CHANGELOG.html">Release History</a></li>
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,6 @@ This part of the documentation begins with some background information about sos
    :maxdepth: 2
 
    user/quickstart
-   user/advanced
    user/support
 
 The API Documentation / Guide

--- a/docs/source/user/advanced.rst
+++ b/docs/source/user/advanced.rst
@@ -1,8 +1,0 @@
-.. _advanced:
-
-Advanced Usage
-==============
-
-In this section, we provide short vignettes that demonstrate the advanced features of our package. These examples showcase practical use cases, highlighting how these features can solve complex problems and enhance your workflow.
-
-[TODO: Demonstrate the advanced features of this package with vignettes built around advanced use cases.]


### PR DESCRIPTION
Remove the advanced section from the user documentation since there are no advanced use cases at this time.