### PR TITLE
docs: design docs don't belong in contributor guide

### DIFF
--- a/docs/source/_templates/sidebarintro.html
+++ b/docs/source/_templates/sidebarintro.html
@@ -23,6 +23,7 @@
 
   <li><a href="https://soso.readthedocs.io/en/latest/dev/contributing.html">Contributors Guide</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/dev/maintaining.html">Maintainers Guide</a></li>
+  <li><a href="https://soso.readthedocs.io/en/latest/dev/design.html">Project Design</a></li>
 
   <p></p>
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,7 +74,6 @@ you.
    :maxdepth: 3
 
    dev/contributing
-   dev/design
    dev/conduct
 
 The Maintainer Guide
@@ -87,3 +86,14 @@ you.
    :maxdepth: 3
 
    dev/maintaining
+
+Project Design
+--------------
+
+The project design documentation provides an overview of the project's
+architecture and design decisions.
+
+.. toctree::
+   :maxdepth: 3
+
+   dev/design


### PR DESCRIPTION
Move design docs from the contributor guide to their own section since design concepts are largely independent of contribution guidelines.