### PR TITLE
fix: strategy_instance returns class, not PosixPath

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Configure the test suite."""
 import socket
-from typing import Any
-import pathlib
+from typing import Any, Type
 from urllib.parse import urlparse
 from numbers import Number
 from copy import deepcopy
@@ -19,7 +18,7 @@ def strategy_names() -> list:
 
 
 @pytest.fixture(params=[EML])
-def strategy_instance(request) -> pathlib.PosixPath:
+def strategy_instance(request) -> Type:
     """
     :returns: The strategy instances.
     """
@@ -29,7 +28,7 @@ def strategy_instance(request) -> pathlib.PosixPath:
 
 
 @pytest.fixture(params=[EML])
-def strategy_instance_no_meta(request) -> pathlib.PosixPath:
+def strategy_instance_no_meta(request) -> Type:
     """
     :returns:   The strategy instances parameterized with an empty metadata
                 file. This is useful for testing negative cases.


### PR DESCRIPTION
Update the type hints for `conftest.strategy_instance` and `conftest.strategy_instance_no_meta` to more accurately describe the return type.