### PR TITLE
refactor: remove unused SSSOM functions

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -8,7 +8,6 @@ import pathlib
 from typing import Any, Union
 import warnings
 import pyshacl.validate
-import pandas as pd
 import requests
 
 
@@ -90,18 +89,6 @@ def get_empty_metadata_file_path(strategy: str) -> pathlib.PosixPath:
     else:
         raise ValueError("Invalid choice!")
     return file_path
-
-
-def read_sssom(strategy: str) -> pd.DataFrame:
-    """Return the SSSOM for the specified strategy.
-
-    :param strategy: Metadata strategy. Can be: EML.
-
-    :returns: The SSSOM table.
-    """
-    sssom_file_path = get_sssom_file_path(strategy)
-    sssom = pd.read_csv(sssom_file_path, delimiter="\t")
-    return sssom
 
 
 def delete_null_values(res: Any) -> Any:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,10 +4,7 @@ import warnings
 from pathlib import PosixPath
 from json import dumps
 import pytest
-from pandas import DataFrame
 from soso.utilities import validate
-from soso.utilities import get_sssom_file_path
-from soso.utilities import read_sssom
 from soso.utilities import get_example_metadata_file_path, get_empty_metadata_file_path
 from soso.utilities import get_shacl_file_path
 from soso.utilities import delete_null_values
@@ -51,27 +48,6 @@ def test_validate_returns_false_when_invalid(internet_connection):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         assert validate("tests/incomplete.jsonld") is False
-
-
-def test_get_sssom_file_path_returns_path(strategy_names):
-    """Test that get_sssom_file_path returns a path for each strategy name.
-
-    This ensures a SSSOM file exists for each strategy and that the path to
-    each is valid."""
-    for strategy in strategy_names:
-        sssom_file_path = get_sssom_file_path(strategy)
-        assert isinstance(sssom_file_path, PosixPath)
-
-
-def test_read_sssom_returns_dataframe(strategy_names):
-    """Test that read_sssom returns a dataframe.
-
-    SSSOM files contain an extensive set of information and can become
-    malformed during manual curation. This test is a very basic check on the
-    format (i.e. can be read without error)."""
-    for strategy in strategy_names:
-        sssom = read_sssom(strategy)
-        assert isinstance(sssom, DataFrame)
 
 
 def test_get_example_metadata_file_path_returns_path(strategy_names):


### PR DESCRIPTION
Remove unused SSSOM functions from the code base. The original intent of these functions was to be part of a system that could enable users to control the accuracy of property method return values based on the mapping predicate stated in the SSSOM file. This is no longer within the project scope.