### PR TITLE
docs: use Poetry in dev workflow

### DIFF
--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -40,7 +40,7 @@ Here are a sequence of steps to help with your code contribution:
 1. Fork the project repository on GitHub.
 2. Create a `feature branch` from the `development` branch.
 3. Install the package by running ``poetry install`` at the command line.
-4. Verify that all tests pass on your system by running ``pytest`` at the command line. In case of failures, conduct a thorough investigation. If you require assistance in diagnosing the issue, follow the guidelines for filing :ref:`bug-reports`.
+4. Verify that all tests pass on your system by running ``poetry run pytest`` at the command line. In case of failures, conduct a thorough investigation. If you require assistance in diagnosing the issue, follow the guidelines for filing :ref:`bug-reports`.
 5. Construct test cases that effectively illustrate the bug or feature.
 6. Implement your changes, including any relevant documentation updates following the `NumPy`_ convention for docstrings.
 7. Re-run the complete test suite to ensure the success of all tests.
@@ -67,8 +67,8 @@ Code Format and Analysis
 Our project uses a couple tools to ensure the code base has a consistent
 style and format as it grows. We use `Black`_ for code formatting and `Pylint`_ for static code analysis. Both can be run from the command line::
 
-    black src/ tests/
-    pylint src/ tests/
+    poetry run black src/ tests/
+    poetry run pylint src/ tests/
 
 .. _Black: https://black.readthedocs.io/en/stable/
 .. _Pylint: https://pylint.pycqa.org/en/latest/
@@ -82,7 +82,7 @@ We greatly appreciate any efforts to enhance our documentation! The documentatio
 
 Build the docs from the command line::
 
-    make --directory=docs clean html
+    poetry run make --directory=docs clean html
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org/index.html

--- a/docs/source/dev/maintaining.rst
+++ b/docs/source/dev/maintaining.rst
@@ -186,21 +186,20 @@ As a maintainer, when developing a new feature, you don't have to fork the proje
 Dependency and Environment Management
 -------------------------------------
 
-We manage package dependencies with `Poetry`_ and provide virtual environments via Poetry and `Conda`_. This means virtual environments must be maintained in two places. An update to one means an update to the other.
+This project uses `Poetry`_ to manage dependencies for development and distribution. Poetry keeps track of necessary packages and their versions, ensuring a consistent development environment.
 
-Please keep the project's environment and requirements files up-to-date. These are located in the project's root directory and can be updated using the following commands:
-
-For the Conda environment::
+For those who prefer using `Conda`_ for environment management, we provide environment files to define the Conda environment. This means package dependencies need to be maintained with Conda as well as Poetry. Update the Conda environment definition using the following commands::
 
     conda env export --from-history --file environment-min.yml
     conda env export --no-builds --file environment.yml
 
-For the pip requirements::
+While Poetry is the recommended method for installation, we offer users an option to install the package using `pip`_. To get a requirements.txt file listing::
 
     pip list --format=freeze > requirements.txt
 
 .. _Poetry: https://python-poetry.org/
 .. _Conda: https://conda.io/projects/conda/en/latest/
+.. _pip: https://pip.pypa.io/en/stable/
 
 Keeping Current with Science-On-Schema.Org
 ------------------------------------------


### PR DESCRIPTION
Use Poetry consistently in the documentation for contributor/developer workflows. A few spots in the documentation demonstrate command line calls using Conda. To align with conventions, these should reference Poetry.