### PR TITLE
docs: sync sidebar html docs

### DIFF
--- a/docs/source/_templates/sidebarlogo.html
+++ b/docs/source/_templates/sidebarlogo.html
@@ -9,7 +9,6 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="https://soso.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
-  <li><a href="https://soso.readthedocs.io/en/latest/user/advanced.html">Advanced Usage</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/user/api.html">API Reference</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/CHANGELOG.html">Release History</a></li>
 
@@ -17,6 +16,7 @@
 
   <li><a href="https://soso.readthedocs.io/en/latest/dev/contributing.html">Contributors Guide</a></li>
   <li><a href="https://soso.readthedocs.io/en/latest/dev/maintaining.html">Maintainers Guide</a></li>
+  <li><a href="https://soso.readthedocs.io/en/latest/dev/design.html">Project Design</a></li>
 
   <p></p>
 


### PR DESCRIPTION
Synchronize the "Useful Links'' section of sidebarlogo.html to match that of sidebarintro.html. sidebarlogo.html should have been updated with recent changes to sidebarintro.html.