### PR TITLE
docs: relocate code of conduct

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,7 +74,6 @@ you.
    :maxdepth: 3
 
    dev/contributing
-   dev/conduct
 
 The Maintainer Guide
 --------------------


### PR DESCRIPTION
Relocate the Code of Conduct from the high-level listing alongside other documents like Contributing. This is an important document, and is already referenced from relevant sections of the user documentation.