### PR TITLE
docs: new strategy methods should use delete_null_values

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -165,6 +165,7 @@ Steps:
   * Create a new module in `src/strategies/` named after the metadata standard.
   * Implement the conversion strategy methods one by one within this directory, starting with stubs.
   * As you develop each method, remove the corresponding skip decorator from the related test case in `tests/test_strategies.py` to ensure testing.
+  * We advocate for property methods that return useful content. Calling the `utilities.delete_null_values` function, before returning results, helps with this.
 
 8. **Verification Tests:**
 


### PR DESCRIPTION
Document the expected usage of the `utilities.delete_null_values` function in strategy methods. This function helps remove null values from the final graph returned by main.convert.