### PR TITLE
fix: get_content_size errors when unit not present

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -314,17 +314,13 @@ def get_content_size(data_entity_element: etree._Element) -> Union[str, None]:
                                     size from.
 
     :returns: The content size of a data entity element.
-
-    Notes:
-        The If the "unit" attribute of the "size" element is defined, it will
-        be appended to the content size value.
     """
     size_element = data_entity_element.xpath(".//physical/size")
     if size_element:
         size = size_element[0].text
         unit = size_element[0].get("unit")
-        if unit:
-            size += " " + unit
+        if size and unit:
+            return size + " " + unit
         return size
     return None
 

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -115,6 +115,18 @@ def test_get_content_size_returns_expected_value():
     root = etree.fromstring(xml_content)
     assert get_content_size(root) == "10"
 
+    # If the "size" value is missing the function will return None, even if the
+    # "unit" attribute is present.
+    xml_content = """
+    <root>
+        <physical>
+            <size unit="kilobytes"></size>
+        </physical>
+    </root>
+    """
+    root = etree.fromstring(xml_content)
+    assert get_content_size(root) is None
+
 
 def test_convert_single_date_time_type_returns_expected_type():
     """Test that the convert_single_date_time_type function returns the


### PR DESCRIPTION
Avoid the `unsupported operand type(s) for +=: 'NoneType' and 'str'` exception raised when `get_content_size` appends a unit string to a size value of NoneType.