### PR TITLE
fix: get_checksum errors on no checksum value

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -673,7 +673,7 @@ def get_checksum(data_entity_element: etree._Element) -> Union[list, None]:
     """
     checksum = []
     for item in data_entity_element.xpath(".//physical/authentication"):
-        if "spdx.org" in item.get("method"):
+        if item.get("method") is not None and "spdx.org" in item.get("method"):
             algorithm = item.get("method").split("#")[-1]
             res = {
                 "@type": "spdx:Checksum",

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -651,6 +651,16 @@ def test_get_checksum():
     root = etree.fromstring(xml_content)
     assert get_checksum(root) is None
 
+    # Missing checksum algorithms are not returned.
+    xml_content = """
+        <root>
+            <physical>
+                <authentication>123456789</authentication>
+            </physical>
+        </root>"""
+    root = etree.fromstring(xml_content)
+    assert get_checksum(root) is None
+
     # Multiple recognized checksum algorithms are returned as a list of dict.
     xml_content = """
     <root>


### PR DESCRIPTION
Fix the `argument of type 'NoneType' is not iterable` exception raised when `get_checksum` returns `None` from the EML authentication element and attempts to perform string matching on it.