### PR TITLE
fix: limit textual property descriptions to 5000 characters

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -4,7 +4,7 @@ from mimetypes import guess_type
 from typing import Union
 from lxml import etree
 from soso.interface import StrategyInterface
-from soso.utilities import delete_null_values
+from soso.utilities import delete_null_values, limit_to_5000_characters
 
 
 class EML(StrategyInterface):
@@ -60,6 +60,7 @@ class EML(StrategyInterface):
             return None
         description = etree.tostring(description[0], encoding="utf-8", method="text")
         description = description.decode("utf-8").strip()
+        description = limit_to_5000_characters(description)  # Google recommendations
         return delete_null_values(description)
 
     def get_url(self) -> None:

--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -218,3 +218,15 @@ def generate_citation_from_doi(url: str, style: str, locale: str) -> Union[str, 
     except requests.exceptions.RequestException as citation_error:
         print(f"An error occurred while generating the citation: " f"{citation_error}")
         return None
+
+
+def limit_to_5000_characters(text: str) -> str:
+    """
+    :param text: The text to limit to 5000 characters.
+
+    :returns:   The text limited to 5000 characters as per Google
+        recommendations for textual properties.
+    """
+    if len(text) > 5000:
+        return text[:5000]
+    return text

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -10,6 +10,7 @@ from soso.utilities import get_shacl_file_path
 from soso.utilities import delete_null_values
 from soso.utilities import delete_unused_vocabularies
 from soso.utilities import generate_citation_from_doi
+from soso.utilities import limit_to_5000_characters
 
 
 @pytest.mark.internet_required
@@ -189,3 +190,13 @@ def test_generate_citation_from_doi():
     doi = "10.6073/pasta/e6c261fbd143e720af5a46a9a131a616"
     citation = generate_citation_from_doi(doi, style="apa", locale="en-US")
     assert citation is None
+
+
+def test_limit_to_5000_characters():
+    """Test that the limit_to_5000_characters function returns a string
+    that is 5000 characters or less."""
+    text = "a" * 5001
+    assert len(text) > 5000
+    assert len(limit_to_5000_characters(text)) <= 5000
+    assert limit_to_5000_characters(text) == text[:5000]
+    assert limit_to_5000_characters("") == ""


### PR DESCRIPTION
Limit textual property descriptions to 5000 characters as per Google's Dataset Structured Data Guidelines. Create a utility function to use across conversion strategies.