### PR TITLE
build: clean up env build files

### DIFF
--- a/environment-min.yml
+++ b/environment-min.yml
@@ -1,4 +1,4 @@
-name: soso-test
+name: soso
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: soso-test
+name: soso
 channels:
   - conda-forge
   - defaults
@@ -115,5 +115,5 @@ dependencies:
   - zstandard=0.23.0
   - zstd=1.5.6
   - pip:
-      - soso==0.0.0
+      - git+https://github.com/clnsmth/soso.git@development
 prefix: /opt/miniconda3/envs/soso-test


### PR DESCRIPTION
Change the conda environment name in environment.yml and environment-min.yml to match the package name for consistency. Install soso from its only distribution on GitHub.