### PR TITLE
fix: future deprecation warning

### DIFF
--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -410,9 +410,9 @@ def convert_single_date_time_type(
         SingleDateTimeType element represents a geologic age, otherwise it
         represents a calendar date and/or time.
     """
-    if not single_date_time:
+    if single_date_time is None:
         return None
-    if not single_date_time.xpath(".//alternativeTimeScale"):
+    if single_date_time.xpath(".//alternativeTimeScale") is None:
         calendar_date = single_date_time.findtext(".//calendarDate")
         time = single_date_time.findtext(".//time")
         instant = (

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -410,9 +410,9 @@ def convert_single_date_time_type(
         SingleDateTimeType element represents a geologic age, otherwise it
         represents a calendar date and/or time.
     """
-    if single_date_time is None:
+    if not single_date_time:
         return None
-    if single_date_time.xpath(".//alternativeTimeScale") is None:
+    if not single_date_time.xpath(".//alternativeTimeScale"):
         calendar_date = single_date_time.findtext(".//calendarDate")
         time = single_date_time.findtext(".//time")
         instant = (

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -410,9 +410,9 @@ def convert_single_date_time_type(
         SingleDateTimeType element represents a geologic age, otherwise it
         represents a calendar date and/or time.
     """
-    if not single_date_time:
+    if len(single_date_time) == 0:
         return None
-    if not single_date_time.xpath(".//alternativeTimeScale"):
+    if len(single_date_time.xpath(".//alternativeTimeScale")) == 0:
         calendar_date = single_date_time.findtext(".//calendarDate")
         time = single_date_time.findtext(".//time")
         instant = (


### PR DESCRIPTION
Use the elem is None test to address the future deprecation warning issued by Pytest.