### PR TITLE
feat: convert multiple versions of source metadata

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -19,7 +19,8 @@ Currently, most repositories have their own implementations, however, a shared i
 
 Functional design requirements we considered in the development of this application:
 
-* Convert any metadata standards to SOSO.
+* Convert any metadata standard to SOSO.
+* Handle various schema versions within supported metadata standards.
 * Test against a consistent set of criteria.
 * Customizable to enable unique use cases.
 
@@ -128,6 +129,18 @@ The test suite utilizes the strategy design pattern to implement a standardized 
 Setting up tests for a new strategy requires only creating a strategy instance, essentially a metadata record read into the strategy module, and running through each method test in the `test_strategies.py` module. To test negative cases, an empty metadata record is used. This helps ensure that strategy methods correctly handle scenarios where the metadata record lacks content.
 
 Strategy-specific utility functions are tested in their own test suite module named `test_[strategy].py`. General utility functions used across different strategies are tested in `test_utilities.py`.
+
+Schema Versioning
+-----------------
+
+To ensure compatibility with multiple versions of supported metadata standards, this application employs a schema version handling mechanism. During conversion:
+
+* The application parses the schema version information directly from the metadata record itself.
+* This extracted information is then stored as an attribute within the conversion strategy.
+* Conversion methods for individual properties can access this schema version attribute allowing the flow control logic within the conversion process to leverage the schema version.
+* Based on the identified version, the logic applies specific processing rules for each property.
+
+This approach ensures that even backward-incompatible changes introduced between schema versions are handled gracefully, maintaining overall conversion success.
 
 Customization
 -------------

--- a/src/soso/interface.py
+++ b/src/soso/interface.py
@@ -15,6 +15,9 @@ class StrategyInterface:
         file:
             The path to the metadata file.
 
+        schema_version:
+            The version of the metadata schema.
+
         kwargs:
             Additional keyword arguments for passing information to the chosen
             `strategy`. This can help in the case of unmappable properties.
@@ -22,10 +25,17 @@ class StrategyInterface:
             information.
     """
 
-    def __init__(self, metadata: Any = None, file: str = None, **kwargs: dict):
+    def __init__(
+        self,
+        metadata: Any = None,
+        file: str = None,
+        schema_version: str = None,
+        **kwargs: dict
+    ):
         """Return the strategy attributes."""
         self.metadata = metadata
         self.file = file
+        self.schema_version = schema_version
         self.kwargs = kwargs
 
     def get_name(self):

--- a/src/soso/strategies/eml.py
+++ b/src/soso/strategies/eml.py
@@ -13,6 +13,8 @@ class EML(StrategyInterface):
     Attributes:
         file:   The path to the metadata file. This should be an XML file in
                 EML format.
+        schema_version: The version of the EML schema used in the metadata
+            file.
         kwargs:   Additional keyword arguments for handling unmappable
                     properties. See the Notes section below for details.
 
@@ -48,6 +50,7 @@ class EML(StrategyInterface):
             raise ValueError(file + " must be an XML file.")
         super().__init__(metadata=etree.parse(file))
         self.file = file
+        self.schema_version = get_schema_version(self.metadata)
         self.kwargs = kwargs
 
     def get_name(self) -> Union[str, None]:
@@ -715,3 +718,16 @@ def get_contributor_elements(metadata: etree.ElementTree) -> Union[list, None]:
         for item in metadata.xpath(xpath):
             contributors.append(item)
     return contributors
+
+
+def get_schema_version(metadata: etree.ElementTree) -> str:
+    """
+    :param metadata:    The EML metadata object as an XML tree.
+
+    :returns:   The version of the EML schema used in the metadata record.
+    """
+    name_space = metadata.getroot().nsmap.get("eml", None)
+    if name_space is None:
+        return None
+    schema_version = name_space.split("/eml-")[-1]
+    return schema_version

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -19,8 +19,9 @@ from soso.strategies.eml import (
     EML,
     get_methods,
     get_checksum,
+    get_schema_version,
 )
-from soso.utilities import get_example_metadata_file_path
+from soso.utilities import get_example_metadata_file_path, get_empty_metadata_file_path
 
 
 def test_get_content_url_returns_expected_value():
@@ -720,3 +721,14 @@ def test_eml_file_input_must_be_xml():
         EML(file=not_xml)
     except ValueError as error:
         assert "must be an XML file" in str(error)
+
+
+def test_get_schema_version_returns_expected_value():
+    """Test that the get_schema_version function returns the expected value."""
+    # Positive case: The function will return the schema version of the EML file.
+    eml = etree.parse(get_example_metadata_file_path("EML"))
+    assert get_schema_version(eml) == "2.2.0"
+    # Negative case: If the schema version is not present, the function will
+    # return None.
+    eml = etree.parse(get_empty_metadata_file_path("EML"))
+    assert get_schema_version(eml) is None

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -17,6 +17,11 @@ def test_interface_has_file_attribute():
     assert hasattr(StrategyInterface(), "file")
 
 
+def test_interface_has_schema_version_attribute():
+    """Test that the StrategyInterface class has a schema_version attribute."""
+    assert hasattr(StrategyInterface(), "schema_version")
+
+
 def test_interface_has_kwargs_attribute():
     """Test that the StrategyInterface class has a kwargs attribute."""
     assert hasattr(StrategyInterface(), "kwargs")

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -38,6 +38,12 @@ def test_strategy_reads_metadata(strategy_instance):
     assert strategy_instance.metadata is not None
 
 
+def test_strategy_reads_schema_version(strategy_instance, strategy_instance_no_meta):
+    """Test that each strategy reads the metadata schema version."""
+    assert isinstance(strategy_instance.schema_version, str)
+    assert strategy_instance_no_meta.schema_version is None
+
+
 # SOSO properties are not universally shared across metadata dialects. In cases
 # where a property is not available, the corresponding strategy method will
 # return None. Therefore, each method test below first checks if the return


### PR DESCRIPTION
Enable processing of multiple versions of a metadata standard based on information contained in a metadata record. This accommodates version-specific properties that require custom processing.

Update the documentation with details about this new feature.