### PR TITLE
ci: fix failing release workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       # Set up job requirements
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
     - name: Check-out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install poetry
       uses: snok/install-poetry@v1
     - name: Install package
@@ -76,12 +76,12 @@ jobs:
     # Define job steps
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
 
     - name: Check-out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_TOKEN }}
@@ -93,9 +93,12 @@ jobs:
       run: poetry install
 
     - name: Use Python Semantic Release to prepare release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          poetry run semantic-release version
           poetry run semantic-release publish
           git checkout development
           git merge main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ black = "^24.0.0"
 python-semantic-release = "^9.0.0"
 
 [tool.semantic_release]
-version_variable = "pyproject.toml:version" # version location
+version_toml = ["pyproject.toml:tool.poetry.version"] # version location
 branch = "convert"                             # branch to make releases of
 changelog_file = "docs/source/CHANGELOG.md" # changelog file
 build_command = "poetry build"              # build dists


### PR DESCRIPTION
- Update the failing release workflow (GitHub Action) so Python Semantic Release can automatically cut a new release when the development branch is merged into `main`.
- Add the `GITHUB_TOKEN` to the semantic release step, where it is needed for committing changes, using the standard syntax for referencing secrets.
- Add the missing versioning command to the semantic release step so the new version is calculated.
- Update to the newest Python actions for setup and checkout.
- Fix outdated syntax for referencing the version number in the `pyproject.toml` file to align with the requirements of the current version of Python Semantic Release.
- Update the `RELEASE_TOKEN` in the repository so Python Semantic Release can commit changes made during the release workflow.