### PR TITLE
docs: correct branch reference for codecov and documentation

### DIFF
--- a/docs/source/dev/maintaining.rst
+++ b/docs/source/dev/maintaining.rst
@@ -97,8 +97,6 @@ When a feature is complete and ready for integration with the project, it should
 
 If at this point, part of the feature was forgotten, don't restore the `feature branch`, rather open a new pull request on `development`, and iterate back through the contributor process.
 
-.. _merging-development-into-convert:
-
 Merging Development into Main
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,8 +11,8 @@ Release v\ |version|. (:ref:`Installation <quickstart>`)
     :target: https://github.com/clnsmth/soso/actions/workflows/ci-cd.yml
     :alt: CI/CD pipeline status
 
-.. image:: https://codecov.io/gh/clnsmth/soso/branch/convert/graph/badge.svg
-    :target: https://app.codecov.io/github/clnsmth/soso?branch=convert
+.. image:: https://codecov.io/gh/clnsmth/soso/branch/main/graph/badge.svg
+    :target: https://app.codecov.io/github/clnsmth/soso?branch=main
     :alt: Code coverage status
 
 For creating `Science On Schema.Org`_ (SOSO) markup in dataset landing pages to improve data discovery through search engines.


### PR DESCRIPTION
Replaced incorrect convert branch reference with main to fix codecov workflow and documentation accuracy. Note, the documentation issue is only an unused reference.