### PR TITLE
fix: incorrect comparison of bytes and string objects

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -259,6 +259,6 @@ def is_url(text: str) -> bool:
         location values.
     """
     res = urlparse(text)
-    if res.scheme != "" and res.netloc != "":
+    if len(res.scheme) > 0 and len(res.netloc) > 0:
         return True
     return False

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -215,3 +215,4 @@ def test_is_url():
     """Test that a string is a URL or not"""
     assert is_url("http://purl.dataone.org/odo/ECSO_00001203") is True
     assert is_url("A free text description.") is False
+    assert is_url(None) is False


### PR DESCRIPTION
Address an issue in the `is_url` function where bytes objects are being compared to string objects using the `==` operator, leading to unexpected results.