### PR TITLE
fix: correct XML declaration in example SPASE file (#213)

### DIFF
--- a/src/soso/data/spase.xml
+++ b/src/soso/data/spase.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Spase xmlns="http://www.spase-group.org/data/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.spase-group.org/data/schema http://www.spase-group.org/data/schema/spase-2-5-0.xsd">
    <Version>2.5.0</Version>


### PR DESCRIPTION
Remove the empty line at the beginning of the example SPASE file to ensure proper XML declaration and prevent parsing errors.