### PR TITLE
fix: prevent invalid property assignments in SOSO records (#218)

### DIFF
--- a/src/soso/main.py
+++ b/src/soso/main.py
@@ -79,9 +79,11 @@ def convert(file: str, strategy: str, **kwargs: dict) -> str:
         "prov:wasGeneratedBy": strategy.get_was_generated_by(),
     }
 
-    # Override with user defined properties
+    # Override with user defined properties. Only override properties that
+    # exist in the graph, because we don't want to add unrecognized properties.
     for key, value in kwargs.items():
-        graph[key] = value
+        if key in graph:
+            graph[key] = value
 
     # Remove properties where get methods returned None, so the user is
     # return a clean graph.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,3 +78,13 @@ def test_convert_with_kwargs(soso_properties):
     res = loads(res)
     for key, value in kwargs.items():
         assert res[key] == value
+
+    # But it should not work in reverse. I.e. any kwargs not in the SOSO
+    # properties should be ignored.
+    res = convert(
+        file=get_example_metadata_file_path("EML"),
+        strategy="eml",
+        **{"not_a_property": "value"},
+    )
+    res = loads(res)
+    assert "not_a_property" not in res


### PR DESCRIPTION
Modify the `main.convert` function to prevent the assignment of unrecognized properties to SOSO records when using the `kwargs` parameter. This ensures data integrity and prevents unexpected behavior.

Closes #218