### PR TITLE
test: add missing `@id` property to test fixture (#213)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def soso_properties() -> list:
     :returns: The names of SOSO properties.
     """
     return [
+        "@id",
         "@context",
         "@type",
         "name",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,6 @@ def test_convert_returns_context(strategy_names):
         assert "@context" in res
 
 
-@pytest.mark.skipif(strategy_instance="SPASE", reason="Not yet implemented")
 def test_convert_returns_expected_properties(strategy_names, soso_properties):
     """Test that the convert function returns the expected properties/keys."""
     for strategy in strategy_names:


### PR DESCRIPTION
Add the missing `@id` property to the `soso_properties` test fixture to prevent test failures caused by the absence of this required property.

This issue was discovered in #220.