### PR TITLE
docs: update pyproject.toml with SPASE authors (#234)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "soso"
 version = "0.4.0"
 description = "For creating Science On Schema.Org (SOSO) markup in dataset landing pages to improve data discovery through search engines."
-authors = ["Colin Smith <colin.smith@wisc.edu>"]
+authors = ["Colin Smith <colin.smith@wisc.edu>", "Zach Boquet", "Rebecca Ringuette"]
 maintainers = ["Colin Smith <colin.smith@wisc.edu>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Update the pyproject.toml authors field to include Zach and Rebecca from the SPASE merge. This change duplicates author information present in .zenodo.json, but ensures consistency across metadata files.

Note, this commit proceeds the SPASE merge, which is imminent.

Closes #234