### PR TITLE
docs: enhance contributing guidelines for clarity (#238)

### DIFF
--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -47,12 +47,11 @@ Here are a sequence of steps to help with your code contribution:
 8. Format and analyze your code according to our :ref:`code-format-and-analysis` guidelines.
 9. Ensure the docs build following the :ref:`documentation-contributions` guidelines.
 10. Check that the sdist and wheels build by running ``poetry build`` at the command line.
-11. Commit your work following our :ref:`commit-message` guidelines.
+11. Commit your work following our :ref:`commit-messages` guidelines.
 12. Submit a GitHub Pull Request to the `development` branch of the upstream repository.
 
 .. _reStructuredText: https://thomas-cokelaer.info/tutorials/sphinx/docstring_python.html
 .. _pytest: https://docs.pytest.org/en/latest/
-.. _Angular commit style: https://github.com/angular/angular/blob/convert/CONTRIBUTING.md#-commit-message-format
 
 Code Review
 ~~~~~~~~~~~
@@ -72,6 +71,12 @@ style and format as it grows. We use `Black`_ for code formatting and `Pylint`_ 
 
 .. _Black: https://black.readthedocs.io/en/stable/
 .. _Pylint: https://pylint.pycqa.org/en/latest/
+
+`Python Type Hints`_ are used to improve static code analysis and code clarity.
+
+*Note, Pylint exceptions may be allowed. If you believe there is a valid reason to deviate from Pylint's requirements for a specific piece of code, please open a GitHub issue to discuss and gain approval for the exception.*
+
+.. _Python Type Hints: https://peps.python.org/pep-0484/
 
 .. _documentation-contributions:
 
@@ -110,11 +115,22 @@ If you are proposing a feature, please use the `Feature request`_ issue template
 
 .. _Feature request: https://github.com/clnsmth/soso/issues/new/choose
 
-.. _commit-message:
+.. _commit-messages:
 
 Commit Messages
 ---------------
 
-Commit messages are incredibly valuable for understanding the project's code. When crafting your commit message, please provide context about the changes being made and the reasons behind them.
+Commit messages are incredibly valuable for understanding the project’s code. When crafting your commit message, please provide context about the changes being made and the reasons behind them.
 
-To ensure readability, we recommend to keep the commit message header under 52 characters and the body within 72 characters.
+We use the `Angular commit style`_. This allows `Python Semantic Release`_ to streamline the release process. Our project uses this style in full with the notable exceptions that the commit message header should not include the scope value, and that any related GitHub issues should be referenced. For example:
+
+``feat: add framework for new feature (#3, #5)``
+
+not
+
+``feat(module): add framework for new feature``
+
+Do your best to keep the commit message header from exceeding 52 characters in length, and the commit message body from exceeding 72 characters.
+
+.. _Angular commit style: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
+.. _Python Semantic Release: https://python-semantic-release.readthedocs.io/en/latest/

--- a/docs/source/dev/maintaining.rst
+++ b/docs/source/dev/maintaining.rst
@@ -21,13 +21,13 @@ Pull request review facilitates refinement of a contribution before it's incorpo
 
 *Though pull request review is required by the project's GitHub branch protection rules, maintainers are allowed to bypass review. Having said this, we generally encourage review in all cases.*
 
-Here are a steps to help with your pull request review:
+Here are steps to help with your pull request review:
 
 1. Start a GitHub review on the pull request.
 2. Check that the :ref:`ci-workflow` passes. Even if successful, check the workflow run logs for Pylint related messages. Though not required, we recommend these messages be addressed.
 3. New features or bug-fixes should include tests demonstrating the change.
 4. Review the diffs of code and related documentation.
-5. Check for compliance with our :ref:`commit-message` style.
+5. Check for compliance with our :ref:`commit-messages` style.
 6. Submit the review.
 
 If collaboration on the pull request is needed, create a `feature branch` in GitHub, change the base branch of the pull request from `development` to the newly created `feature branch`, and merge. This allows the maintainer to lend a helpful hand.
@@ -38,31 +38,6 @@ Git and GitHub
 --------------
 
 We use a combination of git and GitHub features to version control and manage various aspects of our project. Generally, we prefer small, incremental changes that are easy to review and maintain.
-
-.. _commit-message-style:
-
-Commit Message Style
-~~~~~~~~~~~~~~~~~~~~
-
-Our project uses two different commit message styles. The first is used during feature development (see the Contributor's Guide :ref:`commit-message`). The second is used to convert a squash commit when merging a `feature branch` into `development`, and allows `Python Semantic Release`_ to streamline the reoccurring release process.
-
-This second commit style is the `Angular commit style`_. Our project uses this style in full with the notable exceptions that the `commit message header`_ should not include the `scope` value, and that any related GitHub issues should be referenced. For example:
-
-``feat: add framework for new feature (#3, #5)``
-
-not
-
-``feat(module): add framework for new feature``
-
-.. _Python Semantic Release: https://python-semantic-release.readthedocs.io/en/latest/
-.. _Angular commit style: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
-.. _commit message header: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit-message-header
-
-Do your best to keep the commit message header from exceeding 52 characters in length, but no greater than 72 characters, and keep the commit message body from exceeding 72 characters.
-
-*Note, Semantic Release may be bypassed in special circumstances. To do this, simply remove all Angular style "type" keywords from the commit message header.*
-
-
 
 Branch Management
 ~~~~~~~~~~~~~~~~~
@@ -87,7 +62,7 @@ When a feature is complete and ready for integration with the project, it should
 2. Rebase the `feature branch` onto the `development` branch.
 3. Force push your local `feature branch` to the remote `feature branch`.
 4. Ensure the :ref:`ci-workflow` passes.
-5. Squash merge the `feature branch` into `development` using the GitHub pull request interface, and following the Angular commit style mentioned in the :ref:`commit-message-style` guidelines. To do this:
+5. Squash merge the `feature branch` into `development` using the GitHub pull request interface, and following the Angular commit style mentioned in the :ref:`commit-messages` guidelines. To do this:
     i. Edit the commit message header.
     ii. Preserve the commit message body as is (now a squashed set of commits).
     iii. Add keywords in the `commit message footer`_ to close out or mention any related GitHub issues.
@@ -117,7 +92,7 @@ Here's a sequence of steps for merging `development` into `main` and creating a 
 8. Pull the remote `main` and `development` branches back into your local repository. This will keep your local branches in sync with the remote, which the semantic release made modifications to during the release process.
 
 .. _readthedocs.io: https://soso.readthedocs.io/en/latest/
-
+.. _Python Semantic Release: https://python-semantic-release.readthedocs.io/en/latest/
 .. _hot-fixes:
 
 Hot Fixes


### PR DESCRIPTION
Enhance the contributing guidelines, specifically clarifying workflows, static code analysis, and formatting. These aspects are currently implied, but shouldn't be.

Closes #238