### PR TITLE
docs: improve the visibility of the Code of Conduct (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Unmappable properties are listed in the strategy documentation.
 
 The API reference and user guide are available on [Read the Docs](https://soso.readthedocs.io).
 
+## Code of Conduct
+
+In the spirit of collaboration, we emphasize the importance of maintaining a respectful and inclusive environment.
+
+See the [Code of Conduct](https://soso.readthedocs.io/en/latest/dev/conduct.html#conduct) for details.
+

--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -16,8 +16,6 @@ In this project, we uphold a golden rule that applies to all forms of contributi
 
 See the :ref:`Code of Conduct <conduct>` for details.
 
-.. _Code of Conduct: https://soso.readthedocs.io/en/latest/dev/conduct/
-
 Contribution Suitability
 ------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,3 +96,10 @@ architecture and design decisions.
    :maxdepth: 3
 
    dev/design
+
+Code of Conduct
+---------------
+
+In the spirit of collaboration, we emphasize the importance of maintaining a respectful and inclusive environment.
+
+See the :ref:`Code of Conduct <conduct>` for details.


### PR DESCRIPTION
Improve the visibility of the project's Code of Conduct. Currently, the Code of Conduct is "buried" within the contributing guidelines, which can make it difficult for new and existing community members to find and understand the expected standards of behavior.

Closes #239