### PR TITLE
fix: use platform-agnostic pathlib.Path type

### DIFF
--- a/src/soso/utilities.py
+++ b/src/soso/utilities.py
@@ -42,7 +42,7 @@ def validate(graph: str) -> bool:
         return None
 
 
-def get_shacl_file_path() -> pathlib.PosixPath:
+def get_shacl_file_path() -> pathlib.Path:
     """Return the SHACL shape file path for the SOSO dataset graph.
 
     The shape file is for the current release version of the SOSO dataset
@@ -54,7 +54,7 @@ def get_shacl_file_path() -> pathlib.PosixPath:
     return file_path
 
 
-def get_sssom_file_path(strategy: str) -> pathlib.PosixPath:
+def get_sssom_file_path(strategy: str) -> pathlib.Path:
     """Return the SSSOM file path for the specified strategy.
 
     :param strategy: Metadata strategy. Can be: EML.
@@ -66,7 +66,7 @@ def get_sssom_file_path(strategy: str) -> pathlib.PosixPath:
     return file_path
 
 
-def get_example_metadata_file_path(strategy: str) -> pathlib.PosixPath:
+def get_example_metadata_file_path(strategy: str) -> pathlib.Path:
     """Return the file path of an example metadata file.
 
     :param strategy: Metadata strategy. Can be: EML, SPASE.
@@ -82,7 +82,7 @@ def get_example_metadata_file_path(strategy: str) -> pathlib.PosixPath:
     return file_path
 
 
-def get_empty_metadata_file_path(strategy: str) -> pathlib.PosixPath:
+def get_empty_metadata_file_path(strategy: str) -> pathlib.Path:
     """
     :param strategy: Metadata strategy. Can be: EML.
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,7 +1,7 @@
 """For testing the validator module."""
 
 import warnings
-from pathlib import PosixPath
+from pathlib import Path
 from json import dumps
 import pytest
 from soso.utilities import validate, is_url
@@ -56,20 +56,20 @@ def test_get_example_metadata_file_path_returns_path(strategy_names):
     """Test that get_example_metadata returns a path."""
     for strategy in strategy_names:
         file_path = get_example_metadata_file_path(strategy=strategy)
-        assert isinstance(file_path, PosixPath)
+        assert isinstance(file_path, Path)
 
 
 def test_get_empty_metadata_file_path_returns_path(strategy_names):
     """Test that get_empty_metadata_file_path returns a path."""
     for strategy in strategy_names:
         file_path = get_empty_metadata_file_path(strategy=strategy)
-        assert isinstance(file_path, PosixPath)
+        assert isinstance(file_path, Path)
 
 
 def test_get_shacl_file_path_returns_path():
     """Test that get_shacl_file_path returns a path."""
     file_path = get_shacl_file_path()
-    assert isinstance(file_path, PosixPath)
+    assert isinstance(file_path, Path)
 
 
 def test_rm_null_values():


### PR DESCRIPTION
Change function return type hints and test assertions from the platform-specific pathlib.PosixPath to the abstract base class, pathlib.Path.

The use of PosixPath causes type hint issues and test failures on non-POSIX systems. Using the base class makes type hints and tests correct and portable across all operating systems.

Closes #261