### PR TITLE
ci: run CI on pull requests to any branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, development]
   pull_request:
-    branches: [main, development]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Provide immediate feedback to contributors regardless of target branch. This supports intermediate feature branches by providing CI status on pull requests to them, not just the development branch.