### PR TITLE
refactor: ensure SPASE strategy passes linting

### DIFF
--- a/problematicRecords.txt
+++ b/problematicRecords.txt
@@ -1,0 +1,10 @@
+/Users/csmith/Code/soso/SMWG/Person/Stephen.A.Fuselier.xml
+/Users/csmith/Code/soso/SMWG/Person/Roman.G.Gomez.xml
+/Users/csmith/Code/soso/SMWG/Person/James.L.Burch.xml
+/Users/csmith/Code/soso/SMWG/Person/Jolene.S.Pickett.xml
+/Users/csmith/Code/soso/SMWG/Person/MMS_SDC_POC.xml
+/Users/csmith/SMWG/Person/Donald.A.Gurnett.xml
+/Users/csmith/Code/soso/SMWG/Instrument/MMS/4/HotPlasmaCompositionAnalyzer.xml
+/Users/csmith/SMWG/Person/R.Bruce.McKibben.xml
+/Users/csmith/SMWG/Person/James.Connell.xml
+/Users/csmith/SMWG/Person/Ming.Zhang.xml

--- a/src/soso/strategies/spase.py
+++ b/src/soso/strategies/spase.py
@@ -1428,8 +1428,11 @@ def get_dates(
     desired_root = None
     root = metadata.getroot()
     for elt in root.iter(tag=etree.Element):
-        if (elt.tag.endswith("NumericalData") or elt.tag.endswith("DisplayData")
-            or elt.tag.endswith("Collection")):
+        if (
+            elt.tag.endswith("NumericalData")
+            or elt.tag.endswith("DisplayData")
+            or elt.tag.endswith("Collection")
+        ):
             desired_root = elt
     revision_history = []
     release_date = ""
@@ -2029,8 +2032,11 @@ def get_alternate_name(metadata: etree.ElementTree) -> Union[str, None]:
     alternate_name = None
     desired_root = None
     for elt in root.iter(tag=etree.Element):
-        if (elt.tag.endswith("NumericalData") or elt.tag.endswith("DisplayData")
-            or elt.tag.endswith("Collection")):
+        if (
+            elt.tag.endswith("NumericalData")
+            or elt.tag.endswith("DisplayData")
+            or elt.tag.endswith("Collection")
+        ):
             desired_root = elt
     for child in desired_root.iter(tag=etree.Element):
         if child.tag.endswith("ResourceHeader"):
@@ -2113,8 +2119,11 @@ def get_mentions(
     root = metadata.getroot()
     desired_root = None
     for elt in root.iter(tag=etree.Element):
-        if (elt.tag.endswith("NumericalData") or elt.tag.endswith("DisplayData")
-            or elt.tag.endswith("Collection")):
+        if (
+            elt.tag.endswith("NumericalData")
+            or elt.tag.endswith("DisplayData")
+            or elt.tag.endswith("Collection")
+        ):
             desired_root = elt
     mentions = get_relation(desired_root, ["Other"], file, **kwargs)
     return mentions
@@ -2139,8 +2148,11 @@ def get_is_part_of(
     root = metadata.getroot()
     desired_root = None
     for elt in root.iter(tag=etree.Element):
-        if (elt.tag.endswith("NumericalData") or elt.tag.endswith("DisplayData")
-            or elt.tag.endswith("Collection")):
+        if (
+            elt.tag.endswith("NumericalData")
+            or elt.tag.endswith("DisplayData")
+            or elt.tag.endswith("Collection")
+        ):
             desired_root = elt
     is_part_of = get_relation(desired_root, ["PartOf"], file, **kwargs)
     return is_part_of
@@ -2595,6 +2607,7 @@ def get_resource_id(metadata: etree.ElementTree, namespaces: Dict) -> Union[str,
     root = metadata.getroot()
     desired_root = None
     dataset_id = None
+    # pylint: disable=too-many-boolean-expressions
     for elt in root.iter(tag=etree.Element):
         if (
             elt.tag.endswith("NumericalData")


### PR DESCRIPTION
Address linting and formatting issues that arose from the recent merge of the SPASE conversion strategy.