### PR TITLE
test: remove unused argument to fix pylint issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize(argnames, final_params, indirect=True)
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(items):
     """
     Called after all tests are collected; allows modification.
     This version correctly handles multiple markers on a single test.


### PR DESCRIPTION
The 'config' argument to the conftest.py::pytest_collection_modifyitems function should be removed because it is unused, and making Pylint issue an 'unused argument' warning.