### PR TITLE
docs: update the documentation on skipping tests

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -6,16 +6,20 @@ Each test uses two types of strategy instances:
 - A "positive" strategy instance with a complete metadata record.
 - A "negative" strategy instance with an empty metadata record.
 
-Tests are skipped for methods that do not apply to a specific strategy. To skip
-tests, we use the @pytest.mark.skipif decorator with one of the following
-explanations (other rationales may be used as necessary):
+Each test is decorated with `@pytest.mark.parametrize_strategies` to run the
+test for all available strategies. If a test is not applicable to a specific
+strategy, the test is skipped using `@pytest.mark.skip_strategy`, listing the
+strategy and the reason for skipping, which typically falls under one of the
+following explanations (other rationales may be used as necessary):
+
 - "Method Not Yet Implemented": Used during active development when a strategy
-method has not been implemented yet but is planned to be. This tag is removed
-incrementally as methods are implemented.
+  method has not been implemented yet but is planned to be. This tag is removed
+  incrementally as methods are implemented.
+
 - "Property Not in Schema": Applied when the source metadata does not include
-content within the schema for the target property the strategy method is
-intended to extract. In such cases, the corresponding test is skipped
-indefinitely.
+  content within the schema for the target property the strategy method is
+  intended to extract. In such cases, the corresponding test is skipped
+  indefinitely.
 """
 
 import pytest


### PR DESCRIPTION
Update the documentation on skipping tests to describe our new approach introduced in #270.