### PR TITLE
ci: add CODEOWNERS to streamline maintenance (#235)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# These owners are the default owners for everything in the repo. Unless a
+# later match takes precedence.
+* @clnsmth
+
+# SPASE files
+spase-HowToConvert.rst @Kurokio
+spase.py @Kurokio
+conversion.py @Kurokio
+test_spase.py @Kurokio
+soso-spase.sssom.yml @Kurokio
+soso-spase.sssom.tsv @Kurokio
+spase.xml @Kurokio
+spase_empty.xml @Kurokio
+spase.json @Kurokio
+spase-David.T.Young.xml @Kurokio
+spase-FGM.xml @Kurokio
+spase-MMS.xml @Kurokio
+spase-MMS-4.xml @Kurokio
+spase-P1D.xml @Kurokio
+spase-PT0.25S.xml @Kurokio
+spase-PT8S.xml @Kurokio
+spase-PT10M.xml @Kurokio
+spase-PT17M.xml @Kurokio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "soso"
 version = "0.4.0"
 description = "For Converting Metadata Records into Science On Schema.Org Markup"
 authors = ["Colin Smith <colin.smith@wisc.edu>", "Zach Boquet", "Rebecca Ringuette"]
-maintainers = ["Colin Smith <colin.smith@wisc.edu>"]
+maintainers = ["Colin Smith <colin.smith@wisc.edu>", "Zach Boquet"]
 license = "MIT"
 readme = "README.md"
 


### PR DESCRIPTION
Add maintainers for relevant sections of the codebase to streamline pull request reviews and associated maintenance.

Closes #235