### PR TITLE
ci: add to PyPI on release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,22 +91,8 @@ jobs:
           git merge main
           git push origin development
 
-#       - name: Publish to TestPyPI
-#         uses: pypa/gh-action-pypi-publish@release/v1
-#         with:
-#           user: __token__
-#           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#           repository_url: https://test.pypi.org/legacy/
-
-#       - name: Test install from TestPyPI
-#         run: |
-#             pip install \
-#             --index-url https://test.pypi.org/simple/ \
-#             --extra-index-url https://pypi.org/simple \
-#             soso
-
-#       - name: Publish to PyPI
-#         uses: pypa/gh-action-pypi-publish@release/v1
-#         with:
-#           user: __token__
-#           password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![example workflow](https://github.com/clnsmth/soso/actions/workflows/ci-cd.yml/badge.svg)
 [![codecov](https://codecov.io/github/clnsmth/soso/graph/badge.svg?token=2J4MNIXCTD)](https://codecov.io/github/clnsmth/soso)
 [![DOI](https://zenodo.org/badge/666558073.svg)](https://zenodo.org/badge/latestdoi/666558073)
+![PyPI - Version](https://img.shields.io/pypi/v/soso?color=blue)
 
 For converting dataset metadata into [Science On Schema.Org](https://github.com/ESIPFed/science-on-schema.org) markup.
 
@@ -11,9 +12,9 @@ For converting dataset metadata into [Science On Schema.Org](https://github.com/
 
 ### Installation
 
-Currently, `soso` is only available on GitHub.  To install it, you need to have [pip](https://pip.pypa.io/en/stable/installation/) installed. Once pip is installed, you can install `soso` by running the following command in your terminal:
+Install from PyPI:
 
-    $ pip install git+https://github.com/clnsmth/soso.git@main
+    $ pip install soso
 
 ### Metadata Conversion
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,11 +19,22 @@ Release v\ |version|. (:ref:`Installation <quickstart>`)
     :target: https://zenodo.org/badge/latestdoi/666558073
     :alt: Latest Zenodo DOI
 
+.. image:: https://img.shields.io/pypi/v/soso?color=blue&label=pypi
+    :target: https://pypi.org/project/geoenv/
+    :alt: Package version
+
 For converting dataset metadata into `Science On Schema.Org`_ markup.
 
 .. _Science On Schema.Org: https://github.com/ESIPFed/science-on-schema.org
 
 -------------------
+
+**Installation**
+
+Install from PyPI::
+
+   $ pip install soso
+
 
 **Metadata Conversion**
 

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -8,15 +8,9 @@ Welcome to the Quickstart guide! Whether you're a beginner or experienced develo
 Installation
 ------------
 
-Currently, `soso` is only available on GitHub.  To install it, you need to have `pip <https://pip.pypa.io/en/stable/installation/>`_ installed.
+Install from PyPI::
 
-Once pip is installed, you can install `soso` by running the following command in your terminal::
-
-    $ pip install git+https://github.com/clnsmth/soso.git@main
-
-For the latest development version::
-
-    $ pip install git+https://github.com/clnsmth/soso.git@development
+    $ pip install soso
 
 
 Metadata Conversion


### PR DESCRIPTION
Add releases to PyPI for distribution. Also, add the PyPI version badge to the top-level documentation for visibility and update installation instructions to show how to install with pip.