### PR TITLE
fix: ensure temporary SPASE file is properly closed

### DIFF
--- a/src/soso/strategies/spase/spase.py
+++ b/src/soso/strategies/spase/spase.py
@@ -1,5 +1,6 @@
 """The SPASE strategy module."""
 
+import atexit
 import json
 import re
 import os
@@ -34,6 +35,12 @@ from soso.utilities import delete_null_values
 temp_file = tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8")
 temp_file_path = temp_file.name
 # print("Temp file exists?: " + str(os.path.exists(temp_file_path)) + ':' + temp_file_path)
+
+def cleanup_temp_file():
+    if not temp_file.closed:
+        temp_file.close()
+
+atexit.register(cleanup_temp_file)
 
 
 class SPASE(StrategyInterface):


### PR DESCRIPTION
Register cleanup function with atexit to close the temp file on exit and to prevent unclosed file warnings during test runs and normal execution.

This was an oversight in review of PR #285