### PR TITLE
docs: add missing docstring

### DIFF
--- a/src/soso/strategies/spase/spase.py
+++ b/src/soso/strategies/spase/spase.py
@@ -38,6 +38,7 @@ temp_file_path = temp_file.name
 
 
 def cleanup_temp_file():
+    """Cleanup the temporary file on exit."""
     if not temp_file.closed:
         temp_file.close()
 


### PR DESCRIPTION
Add a missing docstring to the temporary file cleanup function. It was forgotten in the original implementation.