### PR TITLE
ci: fix .zenodo.json contributor types

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,32 +24,28 @@
       "name": "Cecconi, Baptiste",
       "orcid": "0000-0001-7915-5571",
       "affiliation": "Observatoire de Paris, Université de Recherche Paris Sciences et Lettres",
-      "type": "Person",
-      "role": "Researcher"
+      "type": "Researcher"
     },
     {
       "name": "Helvey, Tressa",
       "orcid": "0009-0001-1714-839X",
       "affiliation": "Heliophysics Data and Modeling Consortium",
       "ror": "04xbq1n92",
-      "type": "Person",
-      "role": "Researcher"
+      "type": "Researcher"
     },
     {
       "name": "Koval, Andriy",
       "orcid": "0000-0003-1398-1752",
       "affiliation": "University of Maryland, Baltimore County",
       "ror": "02qskvh78",
-      "type": "Person",
-      "role": "Researcher"
+      "type": "Researcher"
     },
     {
       "name": "Byrd, Catherine",
       "orcid": "0009-0006-6661-0938",
       "affiliation": "University of Maryland, Baltimore County",
       "ror": "02qskvh78",
-      "type": "Person",
-      "role": "Researcher"
+      "type": "Researcher"
     }
   ],
   "title": "SOSO: For Converting Metadata Records into Science-On-Schema.Org Markup",


### PR DESCRIPTION
Address allowed value error in validation of .zenodo.json type field.