### PR TITLE
ci: check for release before uploading to PyPI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,6 +80,7 @@ jobs:
       run: poetry install
 
     - name: Use Python Semantic Release to prepare release
+      id: release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -93,6 +94,7 @@ jobs:
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      if: steps.release.outputs.released == 'true'
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Check for a new release before attempting to upload to PyPI. This avoids workflow failure when no release is cut due to a lack of recent commits with release-triggering keywords.