### PR TITLE
refactor: return dictionary with provenance and report (#302)

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,5 @@
 """For testing the validation module."""
 
-import warnings
 from pathlib import Path
 import pytest
 from soso.validation.core import (
@@ -31,44 +30,6 @@ def temp_shacl_file(tmp_path):
     yield str(file_path)
 
 
-@pytest.mark.internet_required
-def test_validate_returns_warning_when_invalid(internet_connection):
-    """Test validate returns a warning when the graph is invalid."""
-    if not internet_connection:
-        pytest.skip("Internet connection is not available.")
-    with pytest.warns(UserWarning, match="Validation Report"):
-        validate("tests/incomplete.jsonld")
-
-
-@pytest.mark.internet_required
-def test_validate_returns_no_warning_when_valid(internet_connection):
-    """Test validate returns no warning when the graph is valid."""
-    if not internet_connection:
-        pytest.skip("Internet connection is not available.")
-    with warnings.catch_warnings(record=True) as list_of_warnings:
-        validate("tests/full.jsonld")
-        for warning in list_of_warnings:
-            assert not issubclass(warning.category, UserWarning)
-
-
-@pytest.mark.internet_required
-def test_validate_returns_true_when_valid(internet_connection):
-    """Test validate returns True when the graph is valid."""
-    if not internet_connection:
-        pytest.skip("Internet connection is not available.")
-    assert validate("tests/full.jsonld") is True
-
-
-@pytest.mark.internet_required
-def test_validate_returns_false_when_invalid(internet_connection):
-    """Test validate returns False when the graph is invalid."""
-    if not internet_connection:
-        pytest.skip("Internet connection is not available.")
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert validate("tests/incomplete.jsonld") is False
-
-
 def test_get_shacl_file_path_returns_path():
     """Test that get_shacl_file_path returns a path."""
     file_path = get_shacl_file_path()
@@ -91,3 +52,23 @@ def test_resolve_shacl_shape_missing_raises_file_not_found():
     """Should raise FileNotFoundError for a non-existent resource"""
     with pytest.raises(FileNotFoundError):
         resolve_shacl_shape("this_shape_does_not_exist.ttl")
+
+
+@pytest.mark.internet_required
+def test_validate_with_bundled_shape():
+    """Validate using a bundled SHACL shape."""
+    bundled_shape = "soso_common_v1.2.3.ttl"
+    shape_path = resolve_shacl_shape(bundled_shape)
+    result = validate("tests/incomplete.jsonld", shacl_graph=shape_path)
+    assert isinstance(result, dict)
+    assert result["shacl_graph"] == shape_path
+    assert "conforms" in result
+
+
+@pytest.mark.internet_required
+def test_validate_with_default_shape():
+    """Validate using the default bundled SHACL shape."""
+    result = validate("tests/incomplete.jsonld", shacl_graph=None)
+    assert "soso_common_v1.2.3.ttl" in result["shacl_graph"]
+    assert isinstance(result, dict)
+    assert "conforms" in result


### PR DESCRIPTION
- Update validate function to return a dict with keys: data_graph, shacl_graph, conforms, report
- Preserve full output from pyshacl.validate for transparency
- Add tests
- Improves usability and downstream consumption of validation results