### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/soso/strategies/eml/eml.py
+++ b/src/soso/strategies/eml/eml.py
@@ -1,6 +1,7 @@
 """The EML strategy module."""
 
 from typing import Union
+from urllib.parse import urlparse
 from lxml import etree
 from soso.interface import StrategyInterface
 from soso.utilities import (
@@ -297,9 +298,19 @@ class EML(StrategyInterface):
 
     def get_license(self) -> Union[str, None]:
         license_url = self.metadata.findtext(".//dataset/licensed/url")
-        if license_url and "spdx.org" in license_url and ".html" in license_url:
-            license_url = license_url[:-5]
-            return delete_null_values(license_url)
+        if not license_url:
+            return None
+
+        parsed = urlparse(license_url)
+        # Accept only SPDX license URLs served directly from spdx.org over HTTP(S),
+        # with a path ending in ".html", then normalize by stripping the suffix.
+        if (
+            parsed.scheme in ("http", "https")
+            and parsed.hostname == "spdx.org"
+            and parsed.path.endswith(".html")
+        ):
+            normalized = license_url[:-5]
+            return delete_null_values(normalized)
         return None
 
     def get_was_revision_of(self) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/clnsmth/soso/security/code-scanning/3](https://github.com/clnsmth/soso/security/code-scanning/3)

In general, the fix is to stop treating the URL as an arbitrary string and instead parse it, then validate its components (at least the hostname and path). For SPDX license URLs, the intended inputs are of the form `https://spdx.org/licenses/<ID>.html`. We should:

1. Parse `license_url` with `urllib.parse.urlparse`.
2. Validate that:
   - The scheme is `http` or `https` (or restrict to `https` if desired).
   - The hostname is exactly `spdx.org` (or `www.spdx.org` if that is expected), not something that merely contains `spdx.org` as a substring.
   - The path ends with `.html`.
3. Only if all checks pass, strip the trailing `.html` from the full URL (preserving scheme and host) exactly as before.

This approach keeps existing functionality (normalizing genuine SPDX license URLs by dropping `.html`) while ensuring that arbitrary URLs containing `spdx.org` somewhere else are not incorrectly normalized and returned. Concretely, in `src/soso/strategies/eml/eml.py`, we need to:

- Add an import for `urlparse` from `urllib.parse` at the top, alongside the existing imports.
- Replace the body of `get_license` so that it uses `urlparse` to inspect the hostname and path, instead of using `"spdx.org" in license_url` and `".html" in license_url`.

No new helper functions are strictly necessary; the logic can be inlined in `get_license` for clarity and minimal change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
