### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   ci:
@@ -56,6 +59,9 @@ jobs:
 
     # Only run this job if new work is pushed to "main"
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      contents: write
 
     # Set up operating system
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/clnsmth/soso/security/code-scanning/2](https://github.com/clnsmth/soso/security/code-scanning/2)

In general, the problem is fixed by defining explicit `permissions` for the workflow or for individual jobs, so that the automatically provided `GITHUB_TOKEN` is limited to the minimum scopes required. This avoids relying on repository/organization defaults (which can be broad and can change over time) and documents the intended access clearly.

The best targeted fix here is:
- Add a workflow-level `permissions` block that is minimal and suitable for the `ci` job: `contents: read` is sufficient for checking out code, and the Codecov action uses its own `CODECOV_TOKEN` secret rather than the `GITHUB_TOKEN`, so it does not require extra token scopes.
- Override permissions for the `cd` job, which uses `GITHUB_TOKEN` (mapped to `GH_TOKEN`) to perform semantic release and push commits. This job needs broader repo write access; a common explicit setting is `contents: write`. If semantic-release also manipulates pull requests or issues, it might need additional scopes, but within the snippet we can conservatively grant `contents: write`, which clearly allows the `git push`/release steps to function.

Concretely:
- In `.github/workflows/ci-cd.yml`, insert a `permissions:` block after the `on:` section that sets `contents: read`.
- In the `cd` job definition, add a `permissions:` block (at the same indentation as `needs:`/`if:`) that sets `contents: write`.
No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
