### PR TITLE
chore(lint): ignore PLR0917 positional argument rule in spase.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = ["PL"]
 ignore = ["PLR2004", "PLR5501"]
 
 [tool.ruff.lint.per-file-ignores]
-"src/soso/strategies/spase/spase.py" = ["PLR0912", "PLW2901", "PLW2901", "PLR0915", "PLR0913", "PLC0206", "PLW0603"]
+"src/soso/strategies/spase/spase.py" = ["PLR0912", "PLW2901", "PLW2901", "PLR0915", "PLR0913", "PLC0206", "PLW0603", "PLR0917"]
 "src/soso/strategies/spase/conversion.py" = ["PLR0912", "PLR0915"]
 
 [build-system]


### PR DESCRIPTION
Add "PLR0917" (Too many positional arguments) to the `per-file-ignores` list for `src/soso/strategies/spase/spase.py` in `pyproject.toml`.

This resolves a GitHub CI workflow failure caused by `ruff 0.16.1` enforcing this newer rule on the `person_format` function definition (which takes 9 positional-or-keyword arguments). Adding the exception preserves the existing function signature and protects backwards compatibility.